### PR TITLE
Implement the systray patch for dwm

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub const BORDERPX: c_uint = 3;
 pub const SNAP: c_uint = 32;
 
 /// 0: sloppy systray follows selected monitor, >0: pin systray to monitor x
-pub const SYSTRAYPINNING: c_uint = 0;
+pub static SYSTRAYPINNING: c_uint = 0;
 /// 0: systray in the right corner, >0: systray on left of status text
 pub const SYSTRAYONLEFT: c_uint = 0;
 /// systray spacing

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,19 @@ use rwm::{Arg, Button, Key, Layout, Rule};
 pub const BORDERPX: c_uint = 3;
 // Snap pixel
 pub const SNAP: c_uint = 32;
+
+/// 0: sloppy systray follows selected monitor, >0: pin systray to monitor x
+pub const SYSTRAYPINNING: c_uint = 0;
+/// 0: systray in the right corner, >0: systray on left of status text
+pub const SYSTRAYONLEFT: c_uint = 0;
+/// systray spacing
+pub const SYSTRAYSPACING: c_uint = 2;
+/// 1: if pinning fails, display systray on the first monitor, False: display
+/// systray on the last monitor
+pub const SYSTRAYPINNINGFAILFIRST: c_int = 1;
+/// 0 means no systray
+pub const SHOWSYSTRAY: c_int = 1;
+
 /// 0 means no bar
 pub const SHOWBAR: c_int = 1;
 /// 0 means bottom bar

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -39,11 +39,22 @@ pub enum Net {
     WMName,
     WMState,
     WMCheck,
+    SystemTray,
+    SystemTrayOP,
+    SystemTrayOrientation,
+    SystemTrayOrientationHorz,
     WMFullscreen,
     ActiveWindow,
     WMWindowType,
     WMWindowTypeDialog,
     ClientList,
+    Last,
+}
+
+pub enum XEmbed {
+    Manager,
+    XEmbed,
+    XEmbedInfo,
     Last,
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,27 +1,44 @@
 use std::{
-    ffi::{c_int, c_uint},
+    ffi::{c_int, c_long, c_uint},
+    mem::MaybeUninit,
     ptr::{addr_of, addr_of_mut, null_mut},
 };
 
 use x11::xlib::{
-    self, CWBorderWidth, CWHeight, CWWidth, CurrentTime, False, KeyCode,
-    MappingKeyboard, NotifyInferior, NotifyNormal, PropertyDelete,
-    ReplayPointer, XEvent, XWindowAttributes, CWX, CWY, XA_WM_HINTS,
-    XA_WM_NAME, XA_WM_NORMAL_HINTS, XA_WM_TRANSIENT_FOR,
+    self, CWBackPixel, CWBorderWidth, CWHeight, CWWidth, CurrentTime, False,
+    KeyCode, MappingKeyboard, NotifyInferior, NotifyNormal, PropertyChangeMask,
+    PropertyDelete, ReplayPointer, ResizeRedirectMask, StructureNotifyMask,
+    XAddToSaveSet, XChangeWindowAttributes, XEvent, XGetWindowAttributes,
+    XMapRaised, XReparentWindow, XSelectInput, XSetWindowAttributes, XSync,
+    XWindowAttributes, CWX, CWY, XA_WM_HINTS, XA_WM_NAME, XA_WM_NORMAL_HINTS,
+    XA_WM_TRANSIENT_FOR,
 };
 
-use rwm::{Arg, Monitor, Window};
+use rwm::{
+    enums::{Col, Scheme, XEmbed},
+    Arg, Client, Monitor, Window,
+};
 
 use crate::{
     arrange, cleanmask,
-    config::{BUTTONS, KEYS, TAGS},
+    config::{self, BUTTONS, KEYS, TAGS},
     configure, drawbar, drawbars, drw,
     enums::{Clk, Net},
-    focus, grabkeys, height, is_visible, manage, recttomon, resizeclient,
-    restack, setclientstate, setfocus, setfullscreen, seturgent, textw,
-    unfocus, unmanage, updatebars, updategeom, updatestatus, updatetitle,
-    updatewindowtype, updatewmhints, width, wintoclient, wintomon, BH, DPY,
-    DRW, MONS, NETATOM, ROOT, SELMON, SH, STEXT, SW, WITHDRAWN_STATE,
+    focus, get_scheme_color, getsystraywidth, grabkeys, height, is_visible,
+    manage, recttomon, removesystrayicon, resizebarwin, resizeclient, restack,
+    sendevent, setclientstate, setfocus, setfullscreen, seturgent, textw,
+    unfocus, unmanage, updatebars, updategeom, updatesizehints, updatestatus,
+    updatesystray, updatesystrayicongeom, updatesystrayiconstate, updatetitle,
+    updatewindowtype, updatewmhints,
+    util::ecalloc,
+    width, wintoclient, wintomon, wintosystrayicon,
+    xembed::{
+        SYSTEM_TRAY_REQUEST_DOCK, XEMBED_EMBEDDED_NOTIFY,
+        XEMBED_EMBEDDED_VERSION, XEMBED_FOCUS_IN, XEMBED_MODALITY_ON,
+        XEMBED_WINDOW_ACTIVATE,
+    },
+    BH, DPY, DRW, MONS, NETATOM, NORMAL_STATE, ROOT, SCHEME, SELMON, SH, STEXT,
+    SW, SYSTRAY, WITHDRAWN_STATE,
 };
 
 pub(crate) fn buttonpress(e: *mut XEvent) {
@@ -57,7 +74,11 @@ pub(crate) fn buttonpress(e: *mut XEvent) {
             } else if ev.x < x + textw(addr_of!((*SELMON).ltsymbol) as *const _)
             {
                 click = Clk::LtSymbol;
-            } else if ev.x > (*SELMON).ww - textw(addr_of!(STEXT) as *const _) {
+            } else if ev.x
+                > (*SELMON).ww
+                    - textw(addr_of!(STEXT) as *const _)
+                    - getsystraywidth() as i32
+            {
                 click = Clk::StatusText;
             } else {
                 click = Clk::WinTitle;
@@ -92,7 +113,140 @@ pub(crate) fn buttonpress(e: *mut XEvent) {
 pub(crate) fn clientmessage(e: *mut XEvent) {
     unsafe {
         let cme = &(*e).client_message;
-        let c = wintoclient(cme.window);
+        let mut c = wintoclient(cme.window);
+
+        if config::SHOWSYSTRAY != 0
+            && cme.window == (*SYSTRAY).win
+            && cme.message_type == NETATOM[Net::SystemTrayOP as usize]
+        {
+            // add systray icons
+            if cme.data.get_long(1) == SYSTEM_TRAY_REQUEST_DOCK as c_long {
+                c = ecalloc(1, size_of::<Client>()).cast();
+            }
+            (*c).win = cme.data.get_long(2) as u64;
+            if (*c).win == 0 {
+                libc::free(c.cast());
+                return;
+            }
+            (*c).mon = SELMON;
+            (*c).next = (*SYSTRAY).icons;
+            (*SYSTRAY).icons = c;
+            let mut wa = MaybeUninit::uninit();
+            if XGetWindowAttributes(DPY, (*c).win, wa.as_mut_ptr()) == 0 {
+                // use sane defaults
+                (*wa.as_mut_ptr()).width = BH;
+                (*wa.as_mut_ptr()).height = BH;
+                (*wa.as_mut_ptr()).border_width = 0;
+            }
+            let wa = wa.assume_init();
+            // Safety: we already returned if c was null in ecalloc. could have
+            // done this earlier too
+            let c = &mut *c;
+
+            c.x = 0;
+            c.oldx = 0;
+            c.y = 0;
+            c.oldy = 0;
+
+            c.w = wa.width;
+            c.oldw = wa.width;
+
+            c.h = wa.height;
+            c.oldh = wa.height;
+
+            c.oldbw = wa.border_width;
+            c.bw = 0;
+            c.isfloating = 1;
+
+            // reuse tags field as mapped status
+            c.tags = 1;
+            updatesizehints(c);
+            updatesystrayicongeom(c, wa.width, wa.height);
+            XAddToSaveSet(DPY, c.win);
+            XSelectInput(
+                DPY,
+                c.win,
+                StructureNotifyMask | PropertyChangeMask | ResizeRedirectMask,
+            );
+            XReparentWindow(DPY, c.win, (*SYSTRAY).win, 0, 0);
+            // use parent's background color
+            let mut swa = XSetWindowAttributes {
+                background_pixmap: 0,
+                background_pixel: get_scheme_color(
+                    SCHEME,
+                    Scheme::Norm as usize,
+                    Col::Bg as usize,
+                )
+                .pixel,
+                border_pixmap: 0,
+                border_pixel: 0,
+                bit_gravity: 0,
+                win_gravity: 0,
+                backing_store: 0,
+                backing_planes: 0,
+                backing_pixel: 0,
+                save_under: 0,
+                event_mask: 0,
+                do_not_propagate_mask: 0,
+                override_redirect: 0,
+                colormap: 0,
+                cursor: 0,
+            };
+            XChangeWindowAttributes(DPY, c.win, CWBackPixel, &mut swa);
+            // TODO this looks like the wrong index. xembed should be used to
+            // index xatom. this could be coincidentally correct since they're
+            // all integers though. the net atom at the same index would be
+            // Net::WMName
+            sendevent(
+                c.win,
+                NETATOM[XEmbed::XEmbed as usize],
+                StructureNotifyMask as i32,
+                CurrentTime as i64,
+                XEMBED_EMBEDDED_NOTIFY as i64,
+                0,
+                (*SYSTRAY).win as i64,
+                XEMBED_EMBEDDED_VERSION as i64,
+            );
+
+            // FIXME (original author) not sure if I have to send these events
+            // too
+            sendevent(
+                c.win,
+                NETATOM[XEmbed::XEmbed as usize],
+                StructureNotifyMask as i32,
+                CurrentTime as i64,
+                XEMBED_FOCUS_IN as i64,
+                0,
+                (*SYSTRAY).win as i64,
+                XEMBED_EMBEDDED_VERSION as i64,
+            );
+            sendevent(
+                c.win,
+                NETATOM[XEmbed::XEmbed as usize],
+                StructureNotifyMask as i32,
+                CurrentTime as i64,
+                XEMBED_WINDOW_ACTIVATE as i64,
+                0,
+                (*SYSTRAY).win as i64,
+                XEMBED_EMBEDDED_VERSION as i64,
+            );
+            sendevent(
+                c.win,
+                NETATOM[XEmbed::XEmbed as usize],
+                StructureNotifyMask as i32,
+                CurrentTime as i64,
+                XEMBED_MODALITY_ON as i64,
+                0,
+                (*SYSTRAY).win as i64,
+                XEMBED_EMBEDDED_VERSION as i64,
+            );
+            XSync(DPY, False);
+            resizebarwin(SELMON);
+            updatesystray();
+            setclientstate(c, NORMAL_STATE);
+
+            return;
+        }
 
         if c.is_null() {
             return;
@@ -217,14 +371,7 @@ pub(crate) fn configurenotify(e: *mut XEvent) {
                         }
                         c = (*c).next;
                     }
-                    xlib::XMoveResizeWindow(
-                        DPY,
-                        (*m).barwin,
-                        (*m).wx,
-                        (*m).by,
-                        (*m).ww as u32,
-                        BH as u32,
-                    );
+                    resizebarwin(m);
                     m = (*m).next;
                 }
                 focus(null_mut());
@@ -237,9 +384,16 @@ pub(crate) fn configurenotify(e: *mut XEvent) {
 pub(crate) fn destroynotify(e: *mut XEvent) {
     unsafe {
         let ev = &(*e).destroy_window;
-        let c = wintoclient(ev.window);
+        let mut c = wintoclient(ev.window);
         if !c.is_null() {
             unmanage(c, 1);
+        } else {
+            c = wintosystrayicon(ev.window);
+            if !c.is_null() {
+                removesystrayicon(c);
+                resizebarwin(SELMON);
+                updatesystray();
+            }
         }
     }
 }
@@ -272,6 +426,9 @@ pub(crate) fn expose(e: *mut XEvent) {
             let m = wintomon(ev.window);
             if !m.is_null() {
                 drawbar(m);
+                if m == SELMON {
+                    updatesystray();
+                }
             }
         }
     }
@@ -345,6 +502,21 @@ pub(crate) fn maprequest(e: *mut XEvent) {
     // in its previous state.
     unsafe {
         let ev = &(*e).map_request;
+        let i = wintosystrayicon(ev.window);
+        if !i.is_null() {
+            sendevent(
+                (*i).win,
+                NETATOM[XEmbed::XEmbed as usize],
+                StructureNotifyMask as i32,
+                CurrentTime as i64,
+                XEMBED_WINDOW_ACTIVATE as i64,
+                0,
+                (*SYSTRAY).win as i64,
+                XEMBED_EMBEDDED_VERSION as i64,
+            );
+            resizebarwin(SELMON);
+            updatesystray();
+        }
         log::trace!("maprequest: XGetWindowAttributes");
         let res = xlib::XGetWindowAttributes(DPY, ev.window, addr_of_mut!(WA));
         // XGetWindowAttributes returns a zero if the function fails
@@ -380,6 +552,19 @@ pub(crate) fn propertynotify(e: *mut XEvent) {
     unsafe {
         let mut trans: Window = 0;
         let ev = &mut (*e).property;
+
+        let c = wintosystrayicon(ev.window);
+        if !c.is_null() {
+            if ev.atom == XA_WM_NORMAL_HINTS {
+                updatesizehints(c);
+                updatesystrayicongeom(c, (*c).w, (*c).h);
+            } else {
+                updatesystrayiconstate(c, ev);
+            }
+            resizebarwin(SELMON);
+            updatesystray();
+        }
+
         if ev.window == ROOT && ev.atom == XA_WM_NAME {
             updatestatus();
         } else if ev.state == PropertyDelete {
@@ -429,13 +614,35 @@ pub(crate) fn unmapnotify(e: *mut XEvent) {
     log::trace!("unmapnotify");
     unsafe {
         let ev = &(*e).unmap;
-        let c = wintoclient(ev.window);
+        let mut c = wintoclient(ev.window);
         if !c.is_null() {
             if ev.send_event != 0 {
                 setclientstate(c, WITHDRAWN_STATE);
             } else {
                 unmanage(c, 0);
             }
+        } else {
+            c = wintosystrayicon(ev.window);
+            if !c.is_null() {
+                // KLUDGE (systray author) sometimes icons occasionally unmap
+                // their windows but do _not_ destroy them. we map those windows
+                // back
+                XMapRaised(DPY, (*c).win);
+                updatesystray();
+            }
+        }
+    }
+}
+
+pub(crate) fn resizerequest(e: *mut XEvent) {
+    log::trace!("resizerequest");
+    unsafe {
+        let ev = &(*e).resize_request;
+        let i = wintosystrayicon(ev.window);
+        if !i.is_null() {
+            updatesystrayicongeom(i, ev.width, ev.height);
+            resizebarwin(SELMON);
+            updatesystray();
         }
     }
 }

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -6,20 +6,21 @@ use libc::{c_char, sigaction, SIGCHLD, SIG_DFL};
 use x11::xlib::{
     ButtonRelease, ConfigureRequest, CurrentTime, DestroyAll, EnterWindowMask,
     Expose, ExposureMask, False, GrabModeAsync, GrabSuccess, MapRequest,
-    MotionNotify, SubstructureRedirectMask, XCheckMaskEvent, XConnectionNumber,
-    XEvent, XGrabPointer, XGrabServer, XKillClient, XMaskEvent,
-    XMoveResizeWindow, XSetCloseDownMode, XSetErrorHandler, XSync,
-    XUngrabPointer, XUngrabServer, XWarpPointer,
+    MotionNotify, NoEventMask, SubstructureRedirectMask, XCheckMaskEvent,
+    XConfigureWindow, XConnectionNumber, XEvent, XGrabPointer, XGrabServer,
+    XKillClient, XMaskEvent, XSetCloseDownMode, XSetErrorHandler, XSync,
+    XUngrabPointer, XUngrabServer, XWarpPointer, XWindowChanges, CWY,
 };
 
-use crate::config::{DMENUCMD, DMENUMON, LOCK_FULLSCREEN, SNAP};
+use crate::config::{DMENUCMD, DMENUMON, LOCK_FULLSCREEN, SHOWSYSTRAY, SNAP};
 use crate::enums::{Cur, WM};
 use crate::util::die;
 use crate::{
     arrange, attach, attachstack, detach, detachstack, drawbar, focus,
-    getrootptr, height, is_visible, nexttiled, pop, recttomon, resize, restack,
-    sendevent, unfocus, updatebarpos, width, xerror, xerrordummy, BH, CURSOR,
-    DPY, HANDLER, MONS, MOUSEMASK, ROOT, SELMON, TAGMASK, WMATOM, XNONE,
+    getrootptr, height, is_visible, nexttiled, pop, recttomon, resize,
+    resizebarwin, restack, sendevent, unfocus, updatebarpos, width, xerror,
+    xerrordummy, BH, CURSOR, DPY, HANDLER, MONS, MOUSEMASK, ROOT, SELMON,
+    SYSTRAY, TAGMASK, WMATOM, XNONE,
 };
 use rwm::{Arg, Client, Layout, Monitor};
 
@@ -27,14 +28,27 @@ pub(crate) unsafe extern "C" fn togglebar(_arg: *const Arg) {
     unsafe {
         (*SELMON).showbar = ((*SELMON).showbar == 0) as c_int;
         updatebarpos(SELMON);
-        XMoveResizeWindow(
-            DPY,
-            (*SELMON).barwin,
-            (*SELMON).wx,
-            (*SELMON).by,
-            (*SELMON).ww as u32,
-            BH as u32,
-        );
+        resizebarwin(SELMON);
+        if SHOWSYSTRAY != 0 {
+            let mut wc = XWindowChanges {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+                border_width: 0,
+                sibling: 0,
+                stack_mode: 0,
+            };
+            if (*SELMON).showbar == 0 {
+                wc.y = -BH;
+            } else if (*SELMON).showbar != 0 {
+                wc.y = 0;
+                if (*SELMON).topbar == 0 {
+                    wc.y = (*SELMON).mh - BH;
+                }
+            }
+            XConfigureWindow(DPY, (*SYSTRAY).win, CWY as u32, &mut wc);
+        }
         arrange(SELMON);
     }
 }
@@ -149,7 +163,17 @@ pub(crate) unsafe extern "C" fn killclient(_arg: *const Arg) {
             return;
         }
 
-        if sendevent((*SELMON).sel, WMATOM[WM::Delete as usize]) == 0 {
+        if sendevent(
+            (*(*SELMON).sel).win,
+            WMATOM[WM::Delete as usize],
+            NoEventMask as i32,
+            WMATOM[WM::Delete as usize] as i64,
+            CurrentTime as i64,
+            0,
+            0,
+            0,
+        ) == 0
+        {
             XGrabServer(DPY);
             XSetErrorHandler(Some(xerrordummy));
             XSetCloseDownMode(DPY, DestroyAll);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ impl Rule {
 }
 
 pub struct Systray {
-    win: Window,
-    icons: *mut Client,
+    pub win: Window,
+    pub icons: *mut Client,
 }
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,11 @@ impl Rule {
     }
 }
 
+pub struct Systray {
+    win: Window,
+    icons: *mut Client,
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Layout {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1187,7 +1187,16 @@ fn updatesystray() {
 }
 
 fn wintosystrayicon(w: Window) -> *mut Client {
-    todo!();
+    unsafe {
+        let mut i = null_mut();
+        if SHOWSYSTRAY == 0 || w == 0 {
+            return i;
+        }
+        cfor!((i = (*SYSTRAY).icons; !i.is_null() && (*i).win != w;
+            i = (*i).next) {});
+
+        i
+    }
 }
 
 fn systraytomon(m: *mut Monitor) -> *mut Monitor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1116,7 +1116,30 @@ fn updatestatus() {
 }
 
 fn updatesystrayicongeom(i: *mut Client, w: c_int, h: c_int) {
-    todo!();
+    if i.is_null() {
+        return;
+    }
+    unsafe {
+        let i = &mut *i;
+        i.h = BH;
+        if w == h {
+            i.w = BH;
+        } else if h == BH {
+            i.w = w;
+        } else {
+            i.w = (BH as f32 * (w as f32 / h as f32)) as i32;
+        }
+        applysizehints(i, &mut i.x, &mut i.y, &mut i.w, &mut i.h, False);
+        // force icons into the systray dimensions if they don't want to
+        if i.h > BH {
+            if i.w == i.h {
+                i.w = BH;
+            } else {
+                i.w = (BH as f32 * (i.w as f32 / i.h as f32)) as i32;
+            }
+            i.h = BH;
+        }
+    }
 }
 
 fn updatesystrayiconstate(i: *mut Client, ev: *mut XPropertyEvent) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::ptr::{addr_of, addr_of_mut, null_mut};
 use std::sync::LazyLock;
 
 use libc::{c_long, c_uchar, sigaction};
+use rwm::enums::XEmbed;
 use x11::keysym::XK_Num_Lock;
 use x11::xft::XftColor;
 use x11::xlib::{
@@ -22,14 +23,16 @@ use x11::xlib::{
     PSize, ParentRelative, PointerMotionMask, PointerRoot, PropModeAppend,
     PropModeReplace, PropertyChangeMask, RevertToPointerRoot, ShiftMask,
     StructureNotifyMask, SubstructureNotifyMask, SubstructureRedirectMask,
-    Success, True, XErrorEvent, XFree, XInternAtom, XSetErrorHandler, CWX, CWY,
-    XA_ATOM, XA_STRING, XA_WINDOW, XA_WM_NAME,
+    Success, True, XDestroyWindow, XErrorEvent, XFree, XInternAtom,
+    XMoveResizeWindow, XPropertyEvent, XSetErrorHandler, XUnmapWindow, CWX,
+    CWY, XA_ATOM, XA_STRING, XA_WINDOW, XA_WM_NAME,
 };
 
-use rwm::{Arg, Client, Cursor, Layout, Monitor, Window};
+use rwm::{Arg, Client, Cursor, Layout, Monitor, Systray, Window};
 
 use config::{
-    BUTTONS, COLORS, FONTS, KEYS, LAYOUTS, RESIZE_HINTS, RULES, TAGS,
+    BUTTONS, COLORS, FONTS, KEYS, LAYOUTS, RESIZE_HINTS, RULES, SHOWSYSTRAY,
+    SYSTRAYONLEFT, SYSTRAYSPACING, TAGS,
 };
 use drw::Drw;
 use enums::{Clk, Col, Cur, Net, Scheme, WM};
@@ -120,6 +123,7 @@ static mut XERRORXLIB: Option<
 
 static mut WMATOM: [Atom; WM::Last as usize] = [0; WM::Last as usize];
 static mut NETATOM: [Atom; Net::Last as usize] = [0; Net::Last as usize];
+static mut XATOM: [Atom; XEmbed::Last as usize] = [0; XEmbed::Last as usize];
 
 static mut DPY: *mut Display = null_mut();
 
@@ -133,7 +137,13 @@ static mut CURSOR: [*mut Cursor; Cur::Last as usize] =
 
 static mut SCHEME: *mut *mut Clr = null_mut();
 
+fn get_scheme_color(scheme: *mut *mut Clr, i: usize, j: usize) -> Clr {
+    unsafe { *(*scheme.add(i)).add(j) }
+}
+
 static mut SCREEN: c_int = 0;
+
+static mut SYSTRAY: *mut Systray = null_mut();
 
 const BROKEN: &CStr = c"broken";
 
@@ -266,6 +276,19 @@ fn setup() {
             XInternAtom(DPY, c"_NET_ACTIVE_WINDOW".as_ptr(), False);
         NETATOM[Net::Supported as usize] =
             XInternAtom(DPY, c"_NET_SUPPORTED".as_ptr(), False);
+
+        NETATOM[Net::SystemTray as usize] =
+            XInternAtom(DPY, c"_NET_SYSTEM_TRAY_S0".as_ptr(), False);
+        NETATOM[Net::SystemTrayOP as usize] =
+            XInternAtom(DPY, c"_NET_SYSTEM_TRAY_OPCODE".as_ptr(), False);
+        NETATOM[Net::SystemTrayOrientation as usize] =
+            XInternAtom(DPY, c"_NET_SYSTEM_TRAY_ORIENTATION".as_ptr(), False);
+        NETATOM[Net::SystemTrayOrientationHorz as usize] = XInternAtom(
+            DPY,
+            c"_NET_SYSTEM_TRAY_ORIENTATION_HORZ".as_ptr(),
+            False,
+        );
+
         NETATOM[Net::WMName as usize] =
             XInternAtom(DPY, c"_NET_WM_NAME".as_ptr(), False);
         NETATOM[Net::WMState as usize] =
@@ -281,6 +304,13 @@ fn setup() {
         NETATOM[Net::ClientList as usize] =
             XInternAtom(DPY, c"_NET_CLIENT_LIST".as_ptr(), False);
 
+        XATOM[XEmbed::Manager as usize] =
+            XInternAtom(DPY, c"MANAGER".as_ptr(), False);
+        XATOM[XEmbed::XEmbed as usize] =
+            XInternAtom(DPY, c"_XEMBED".as_ptr(), False);
+        XATOM[XEmbed::XEmbedInfo as usize] =
+            XInternAtom(DPY, c"_XEMBED_INFO".as_ptr(), False);
+
         /* init cursors */
         CURSOR[Cur::Normal as usize] = drw::cur_create(DRW, XC_LEFT_PTR as i32);
         CURSOR[Cur::Resize as usize] = drw::cur_create(DRW, XC_SIZING as i32);
@@ -291,6 +321,9 @@ fn setup() {
         for i in 0..COLORS.len() {
             *SCHEME.add(i) = drw::scm_create(DRW, &COLORS[i], 3);
         }
+
+        // init system tray
+        updatesystray();
 
         /* init bars */
         updatebars();
@@ -435,31 +468,61 @@ fn setfocus(c: *mut Client) {
                 1,
             );
         }
-        sendevent(c, WMATOM[WM::TakeFocus as usize]);
+        sendevent(
+            (*c).win,
+            WMATOM[WM::TakeFocus as usize],
+            NoEventMask as i32,
+            WMATOM[WM::TakeFocus as usize] as i64,
+            CurrentTime as i64,
+            0,
+            0,
+            0,
+        );
     }
 }
 
-fn sendevent(c: *mut Client, proto: Atom) -> c_int {
+fn sendevent(
+    w: Window,
+    proto: Atom,
+    mask: c_int,
+    d0: c_long,
+    d1: c_long,
+    d2: c_long,
+    d3: c_long,
+    d4: c_long,
+) -> c_int {
     log::trace!("sendevent");
     let mut n = 0;
     let mut protocols = std::ptr::null_mut();
+    let mt;
     let mut exists = 0;
     unsafe {
-        if xlib::XGetWMProtocols(DPY, (*c).win, &mut protocols, &mut n) != 0 {
-            while exists == 0 && n > 0 {
-                exists = (*protocols.offset(n as isize) == proto) as c_int;
-                n -= 1;
+        if proto == WMATOM[WM::TakeFocus as usize]
+            || proto == WMATOM[WM::Delete as usize]
+        {
+            mt = WMATOM[WM::Protocols as usize];
+            if xlib::XGetWMProtocols(DPY, w, &mut protocols, &mut n) != 0 {
+                while exists == 0 && n > 0 {
+                    exists = (*protocols.offset(n as isize) == proto) as c_int;
+                    n -= 1;
+                }
+                XFree(protocols.cast());
             }
-            XFree(protocols.cast());
+        } else {
+            exists = 1;
+            mt = proto;
         }
         if exists != 0 {
             let mut ev = xlib::XEvent { type_: ClientMessage };
-            ev.client_message.window = (*c).win;
-            ev.client_message.message_type = WMATOM[WM::Protocols as usize];
+            ev.client_message.window = w;
+            ev.client_message.message_type = mt;
             ev.client_message.format = 32;
-            ev.client_message.data.set_long(0, proto as c_long);
-            ev.client_message.data.set_long(1, CurrentTime as c_long);
-            xlib::XSendEvent(DPY, (*c).win, False, NoEventMask, &mut ev);
+            ev.client_message.data.set_long(0, d0);
+            ev.client_message.data.set_long(1, d1);
+            ev.client_message.data.set_long(2, d2);
+            ev.client_message.data.set_long(3, d3);
+            ev.client_message.data.set_long(4, d4);
+            xlib::XSendEvent(DPY, w, False, mask as i64, &mut ev);
         }
         exists
     }
@@ -657,6 +720,23 @@ fn resizeclient(c: *mut Client, x: i32, y: i32, w: i32, h: i32) {
         );
         configure(c);
         xlib::XSync(DPY, False);
+    }
+}
+
+fn resizebarwin(m: *mut Monitor) {
+    unsafe {
+        let mut w = (*m).ww;
+        if SHOWSYSTRAY != 0 && m == systraytomon(m) && SYSTRAYONLEFT == 0 {
+            w -= getsystraywidth() as i32;
+        }
+        XMoveResizeWindow(
+            DPY,
+            (*m).barwin,
+            (*m).wx,
+            (*m).by,
+            w as u32,
+            BH as u32,
+        );
     }
 }
 
@@ -1031,7 +1111,28 @@ fn updatestatus() {
             libc::strcpy(addr_of_mut!(STEXT) as *mut _, c"rwm-1.0".as_ptr());
         }
         drawbar(SELMON);
+        updatesystray();
     }
+}
+
+fn updatesystrayicongeom(i: *mut Client, w: c_int, h: c_int) {
+    todo!();
+}
+
+fn updatesystrayiconstate(i: *mut Client, ev: *mut XPropertyEvent) {
+    todo!();
+}
+
+fn updatesystray() {
+    todo!();
+}
+
+fn wintosystrayicon(w: Window) -> *mut Client {
+    todo!();
+}
+
+fn systraytomon(m: *mut Monitor) -> *mut Monitor {
+    todo!();
 }
 
 fn textw(x: *const c_char) -> c_int {
@@ -1043,9 +1144,17 @@ fn drawbar(m: *mut Monitor) {
     log::trace!("drawbar");
     unsafe {
         let mut tw = 0;
+        let mut stw = 0;
         let boxs = (*(*DRW).fonts).h / 9;
         let boxw = (*(*DRW).fonts).h / 6 + 2;
         let (mut occ, mut urg) = (0, 0);
+
+        if config::SHOWSYSTRAY != 0
+            && m == systraytomon(m)
+            && config::SYSTRAYONLEFT == 0
+        {
+            stw = getsystraywidth();
+        }
 
         if (*m).showbar == 0 {
             return;
@@ -1055,18 +1164,20 @@ fn drawbar(m: *mut Monitor) {
         if m == SELMON {
             // status is only drawn on selected monitor
             drw::setscheme(DRW, *SCHEME.add(Scheme::Norm as usize));
-            tw = textw(addr_of!(STEXT) as *const _) - LRPAD + 2; // 2px right padding
+            tw = textw(addr_of!(STEXT) as *const _) - LRPAD / 2 + 2; // 2px right padding
             drw::text(
                 DRW,
-                (*m).ww - tw,
+                (*m).ww - tw - stw as i32,
                 0,
                 tw as u32,
                 BH as u32,
-                0,
+                (LRPAD / 2 - 2) as u32,
                 addr_of!(STEXT) as *const _,
                 0,
             );
         }
+
+        resizebarwin(m);
 
         let mut c = (*m).clients;
         while !c.is_null() {
@@ -1132,7 +1243,7 @@ fn drawbar(m: *mut Monitor) {
             0,
         ) as i32;
 
-        let w = (*m).ww - tw - x;
+        let w = (*m).ww - tw - stw as i32 - x;
         if w > BH {
             if !(*m).sel.is_null() {
                 drw::setscheme(
@@ -1169,7 +1280,14 @@ fn drawbar(m: *mut Monitor) {
                 drw::rect(DRW, x, 0, w as u32, BH as u32, 1, 1);
             }
         }
-        drw::map(DRW, (*m).barwin, 0, 0, (*m).ww as u32, BH as u32);
+        drw::map(
+            DRW,
+            (*m).barwin,
+            0,
+            0,
+            (*m).ww as u32 - stw as u32,
+            BH as u32,
+        );
     }
 }
 
@@ -1245,12 +1363,16 @@ fn updatebars() {
             if (*m).barwin != 0 {
                 continue;
             }
+            let mut w = (*m).ww;
+            if SHOWSYSTRAY != 0 && m == systraytomon(m) {
+                w -= getsystraywidth() as i32;
+            }
             (*m).barwin = xlib::XCreateWindow(
                 DPY,
                 ROOT,
                 (*m).wx as c_int,
                 (*m).by as c_int,
-                (*m).ww as c_uint,
+                w as c_uint,
                 BH as c_uint,
                 0,
                 xlib::XDefaultDepth(DPY, SCREEN),
@@ -1264,6 +1386,9 @@ fn updatebars() {
                 (*m).barwin,
                 (*CURSOR[Cur::Normal as usize]).cursor,
             );
+            if SHOWSYSTRAY != 0 && m == systraytomon(m) {
+                xlib::XMapRaised(DPY, (*SYSTRAY).win);
+            }
             xlib::XMapRaised(DPY, (*m).barwin);
             xlib::XSetClassHint(DPY, (*m).barwin, &mut ch);
             m = (*m).next;
@@ -1470,6 +1595,23 @@ fn recttomon(x: c_int, y: c_int, w: c_int, h: c_int) -> *mut Monitor {
     }
 }
 
+fn removesystrayicon(i: *mut Client) {
+    unsafe {
+        if SHOWSYSTRAY == 0 || i.is_null() {
+            return;
+        }
+        let mut ii: *mut *mut Client;
+        cfor!((
+            ii = &mut (*SYSTRAY).icons as *mut _;
+            !ii.is_null() && *ii != i;
+            ii = &mut (*(*ii)).next) {});
+        if !ii.is_null() {
+            *ii = (*i).next;
+        }
+        libc::free(i.cast());
+    }
+}
+
 // "macros"
 
 #[inline]
@@ -1641,6 +1783,12 @@ fn cleanup() {
             cleanupmon(MONS);
         }
 
+        if config::SHOWSYSTRAY != 0 {
+            XUnmapWindow(DPY, (*SYSTRAY).win);
+            XDestroyWindow(DPY, (*SYSTRAY).win);
+            libc::free(SYSTRAY.cast());
+        }
+
         for cur in CURSOR {
             drw::cur_free(DRW, cur);
         }
@@ -1765,6 +1913,7 @@ static HANDLER: LazyLock<
     ret[x11::xlib::MapRequest as usize] = handlers::maprequest;
     ret[x11::xlib::MotionNotify as usize] = handlers::motionnotify;
     ret[x11::xlib::PropertyNotify as usize] = handlers::propertynotify;
+    ret[x11::xlib::ResizeRequest as usize] = handlers::resizerequest;
     ret[x11::xlib::UnmapNotify as usize] = handlers::unmapnotify;
     ret
 });
@@ -2064,6 +2213,12 @@ fn getatomprop(c: *mut Client, prop: Atom) -> Atom {
     let mut da = 0;
     let mut atom: Atom = 0;
     unsafe {
+        // FIXME (systray author) getatomprop should return the number of items
+        // and a pointer to the stored data instead of this workaround
+        let mut req = XA_ATOM;
+        if prop == XATOM[XEmbed::XEmbedInfo as usize] {
+            req = XATOM[XEmbed::XEmbedInfo as usize];
+        }
         if xlib::XGetWindowProperty(
             DPY,
             (*c).win,
@@ -2071,7 +2226,7 @@ fn getatomprop(c: *mut Client, prop: Atom) -> Atom {
             0,
             std::mem::size_of::<Atom>() as i64,
             False,
-            XA_ATOM,
+            req,
             &mut da,
             &mut di,
             &mut dl,
@@ -2083,10 +2238,32 @@ fn getatomprop(c: *mut Client, prop: Atom) -> Atom {
             // the C code is *(Atom *)p. is that different from (Atom) *p?
             // that's closer to what I had before
             atom = *(p as *mut Atom);
+            if da == XATOM[XEmbed::XEmbedInfo as usize] && dl == 2 {
+                atom = *(p as *mut Atom).add(1);
+            }
             XFree(p.cast());
         }
     }
     atom
+}
+
+fn getsystraywidth() -> c_uint {
+    unsafe {
+        let mut w = 0;
+        let mut i = null_mut();
+        if config::SHOWSYSTRAY != 0 {
+            cfor!((
+            i = (*SYSTRAY).icons;
+            !i.is_null();
+            (w, i) = (w + (*i).w + config::SYSTRAYSPACING as i32, (*i).next))
+            {});
+        }
+        if w != 0 {
+            w as c_uint + SYSTRAYSPACING
+        } else {
+            1
+        }
+    }
 }
 
 fn applyrules(c: *mut Client) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2216,6 +2216,7 @@ mod handlers;
 mod key_handlers;
 mod layouts;
 mod util;
+mod xembed;
 
 fn main() {
     env_logger::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,6 +487,7 @@ fn setfocus(c: *mut Client) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sendevent(
     w: Window,
     proto: Atom,
@@ -1151,7 +1152,7 @@ fn updatesystrayicongeom(i: *mut Client, w: c_int, h: c_int) {
 fn updatesystrayiconstate(i: *mut Client, ev: *mut XPropertyEvent) {
     unsafe {
         let mut flags: Atom = 0;
-        let mut code = 0;
+        let code;
         if SHOWSYSTRAY == 0
             || i.is_null()
             || (*ev).atom != XATOM[XEmbed::XEmbedInfo as usize]
@@ -1212,10 +1213,10 @@ fn updatesystray() {
     unsafe {
         let mut wa = default_window_attributes();
         let mut wc: XWindowChanges;
-        let mut i: *mut Client = null_mut();
-        let mut m: *mut Monitor = systraytomon(null_mut());
+        let mut i: *mut Client;
+        let m: *mut Monitor = systraytomon(null_mut());
         let mut x: c_int = (*m).mx + (*m).mw;
-        let mut sw =
+        let sw =
             textw(addr_of!(STEXT) as *const _) - LRPAD + SYSTRAYSPACING as i32;
         let mut w = 1;
 
@@ -1287,8 +1288,8 @@ fn updatesystray() {
                     CurrentTime as i64,
                     NETATOM[Net::SystemTray as usize] as i64,
                     (*SYSTRAY).win as i64,
-                    0 as i64,
-                    0 as i64,
+                    0_i64,
+                    0_i64,
                 );
                 XSync(DPY, False);
             } else {
@@ -1360,9 +1361,9 @@ fn wintosystrayicon(w: Window) -> *mut Client {
 
 fn systraytomon(m: *mut Monitor) -> *mut Monitor {
     unsafe {
-        let mut t: *mut Monitor = null_mut();
-        let mut i = 0;
-        let mut n = 0;
+        let mut t: *mut Monitor;
+        let mut i;
+        let mut n;
         if SYSTRAYPINNING == 0 {
             if m.is_null() {
                 return SELMON;
@@ -1532,14 +1533,7 @@ fn drawbar(m: *mut Monitor) {
                 drw::rect(DRW, x, 0, w as u32, BH as u32, 1, 1);
             }
         }
-        drw::map(
-            DRW,
-            (*m).barwin,
-            0,
-            0,
-            (*m).ww as u32 - stw as u32,
-            BH as u32,
-        );
+        drw::map(DRW, (*m).barwin, 0, 0, (*m).ww as u32 - stw, BH as u32);
     }
 }
 
@@ -2502,7 +2496,7 @@ fn getatomprop(c: *mut Client, prop: Atom) -> Atom {
 fn getsystraywidth() -> c_uint {
     unsafe {
         let mut w = 0;
-        let mut i = null_mut();
+        let mut i;
         if config::SHOWSYSTRAY != 0 {
             cfor!((
             i = (*SYSTRAY).icons;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ use rwm::{Arg, Client, Cursor, Layout, Monitor, Systray, Window};
 
 use config::{
     BUTTONS, COLORS, FONTS, KEYS, LAYOUTS, RESIZE_HINTS, RULES, SHOWSYSTRAY,
-    SYSTRAYONLEFT, SYSTRAYSPACING, TAGS,
+    SYSTRAYONLEFT, SYSTRAYPINNING, SYSTRAYPINNINGFAILFIRST, SYSTRAYSPACING,
+    TAGS,
 };
 use drw::Drw;
 use enums::{Clk, Col, Cur, Net, Scheme, WM};
@@ -1200,7 +1201,32 @@ fn wintosystrayicon(w: Window) -> *mut Client {
 }
 
 fn systraytomon(m: *mut Monitor) -> *mut Monitor {
-    todo!();
+    unsafe {
+        let mut t: *mut Monitor = null_mut();
+        let mut i = 0;
+        let mut n = 0;
+        if SYSTRAYPINNING == 0 {
+            if m.is_null() {
+                return SELMON;
+            }
+            if m == SELMON {
+                return m;
+            } else {
+                return null_mut();
+            }
+        }
+        cfor!(((n, t) = (1, MONS);
+            !t.is_null() && !(*t).next.is_null();
+            (n, t) = (n+1, (*t).next)) {});
+        cfor!(((i, t) = (1, MONS);
+            !t.is_null() && !(*t).next.is_null() && i < SYSTRAYPINNING;
+            (i, t) = (i+1, (*t).next)) {});
+        if SYSTRAYPINNINGFAILFIRST != 0 && n < SYSTRAYPINNING {
+            return MONS;
+        }
+
+        t
+    }
 }
 
 fn textw(x: *const c_char) -> c_int {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@ pub(crate) fn die(msg: &str) {
     std::process::exit(1);
 }
 
+/// Attempt to allocate with `libc::calloc` and die if the result is null
 pub(crate) fn ecalloc(nmemb: size_t, size: size_t) -> *mut c_void {
     log::trace!("ecalloc: nmemb = {nmemb}, size = {size}");
     let ret = unsafe { libc::calloc(nmemb, size) };

--- a/src/xembed.rs
+++ b/src/xembed.rs
@@ -1,0 +1,17 @@
+use std::ffi::c_int;
+
+pub(crate) const SYSTEM_TRAY_REQUEST_DOCK: c_int = 0;
+
+/* XEMBED messages */
+pub(crate) const XEMBED_EMBEDDED_NOTIFY: c_int = 0;
+pub(crate) const XEMBED_FOCUS_IN: c_int = 4;
+pub(crate) const XEMBED_MODALITY_ON: c_int = 10;
+
+pub(crate) const XEMBED_MAPPED: c_int = 1 << 0;
+pub(crate) const XEMBED_WINDOW_ACTIVATE: c_int = 1;
+pub(crate) const XEMBED_WINDOW_DEACTIVATE: c_int = 2;
+
+pub(crate) const VERSION_MAJOR: c_int = 0;
+pub(crate) const VERSION_MINOR: c_int = 0;
+pub(crate) const XEMBED_EMBEDDED_VERSION: c_int =
+    (VERSION_MAJOR << 16) | VERSION_MINOR;

--- a/src/xembed.rs
+++ b/src/xembed.rs
@@ -7,7 +7,7 @@ pub(crate) const XEMBED_EMBEDDED_NOTIFY: c_int = 0;
 pub(crate) const XEMBED_FOCUS_IN: c_int = 4;
 pub(crate) const XEMBED_MODALITY_ON: c_int = 10;
 
-pub(crate) const XEMBED_MAPPED: c_int = 1 << 0;
+pub(crate) const XEMBED_MAPPED: u64 = 1 << 0;
 pub(crate) const XEMBED_WINDOW_ACTIVATE: c_int = 1;
 pub(crate) const XEMBED_WINDOW_DEACTIVATE: c_int = 2;
 


### PR DESCRIPTION
[Patch page](https://dwm.suckless.org/patches/systray/)

I implemented the [2021 version](https://dwm.suckless.org/patches/systray/dwm-systray-20210418-67d76bd.diff) and realized afterward that there was a more recent [2023 version](https://dwm.suckless.org/patches/systray/dwm-systray-20230922-9f88553.diff), but a fairly thorough skim of the diff between the two looks like the only changes to the 2023 patch involve changes to dwm itself.

I've tested this in a VM, and it seems to be working minus showing anything when I hover over the icons. That might be normal in the VM, so I just want to check that it works as expected on my physical hardware before merging.