### PR TITLE
Add scratchpad patch

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -137,19 +137,35 @@ pub static DMENUCMD: DmenuCmd = DmenuCmd([
 ]);
 pub const TERMCMD: [*const c_char; 2] = [c"st".as_ptr(), null_mut()];
 
+pub const SCRATCHPADNAME: *const c_char = c"scratchpad".as_ptr();
+pub const SCRATCHPADCMD: [*const c_char; 6] = [
+    c"st".as_ptr(),
+    c"-t".as_ptr(),
+    SCRATCHPADNAME,
+    c"-g".as_ptr(),
+    c"120x34".as_ptr(),
+    null_mut(),
+];
+
 use x11::keysym::{
-    XK_Return, XK_Tab, XK_b, XK_c, XK_comma, XK_d, XK_f, XK_h, XK_i, XK_j,
-    XK_k, XK_l, XK_m, XK_p, XK_period, XK_q, XK_space, XK_t, XK_0, XK_1, XK_2,
-    XK_3, XK_4, XK_5, XK_6, XK_7, XK_8, XK_9,
+    XK_Return, XK_Tab, XK_b, XK_c, XK_comma, XK_d, XK_f, XK_grave, XK_h, XK_i,
+    XK_j, XK_k, XK_l, XK_m, XK_p, XK_period, XK_q, XK_space, XK_t, XK_0, XK_1,
+    XK_2, XK_3, XK_4, XK_5, XK_6, XK_7, XK_8, XK_9,
 };
 
-pub static KEYS: [Key; 60] = [
+pub static KEYS: [Key; 61] = [
     Key::new(MODKEY, XK_p, spawn, Arg { v: DMENUCMD.0.as_ptr().cast() }),
     Key::new(
         MODKEY | ShiftMask,
         XK_Return,
         spawn,
         Arg { v: TERMCMD.as_ptr().cast() },
+    ),
+    Key::new(
+        MODKEY,
+        XK_grave,
+        togglescratch,
+        Arg { v: SCRATCHPADCMD.as_ptr().cast() },
     ),
     Key::new(MODKEY, XK_b, togglebar, Arg { i: 0 }),
     Key::new(MODKEY, XK_j, focusstack, Arg { i: 1 }),

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -676,13 +676,12 @@ pub(crate) unsafe extern "C" fn togglescratch(arg: *const Arg) {
         let mut found = false;
         cfor!((
         c = (*SELMON).clients;
-        !c.is_null() && (*c).tags & SCRATCHTAG == 0;
+        !c.is_null();
         c = (*c).next) {
-            // this is duplicated from the (negated) loop condition because
-            // we can't do an in-line assigment like C:
-            //
-            // !(found = c->tags & scratchtag)
-            found = (*c).tags & SCRATCHTAG != 0;
+            found = ((*c).tags & SCRATCHTAG) != 0;
+            if found {
+                break;
+            }
         });
         if found {
             let newtagset =

--- a/src/main.rs
+++ b/src/main.rs
@@ -2421,6 +2421,11 @@ fn manage(w: Window, wa: *mut xlib::XWindowAttributes) {
         (*c).y = max((*c).y, (*(*c).mon).wy as i32);
         (*c).bw = config::BORDERPX as i32;
 
+        // TODO pretty sure this doesn't work with pertags, which explains some
+        // behavior I saw before in dwm. probably need to operate on
+        // selmon.pertag.tags[selmon.pertag.curtag]
+        (*SELMON).tagset[(*SELMON).seltags as usize] &= !SCRATCHTAG;
+
         log::trace!("manage: XWindowChanges");
         let mut wc = xlib::XWindowChanges {
             x: 0,
@@ -2757,6 +2762,8 @@ fn unswallow(c: *mut Client) {
 const TAGMASK: u32 = (1 << TAGS.len()) - 1;
 const BUTTONMASK: i64 = ButtonPressMask | ButtonReleaseMask;
 const MOUSEMASK: i64 = BUTTONMASK | PointerMotionMask;
+
+static SCRATCHTAG: u32 = 1 << TAGS.len();
 
 fn updatetitle(c: *mut Client) {
     log::trace!("updatetitle");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2434,7 +2434,7 @@ fn manage(w: Window, wa: *mut xlib::XWindowAttributes) {
             (*(*c).mon).tagset[(*(*c).mon).seltags as usize] |= (*c).tags;
             (*c).isfloating = true;
             (*c).x = (*(*c).mon).wx + (*(*c).mon).ww / 2 - width(c) / 2;
-            (*c).y = (*(*c).mon).wy + (*(*c).mon).wh / 2 - width(c) / 2;
+            (*c).y = (*(*c).mon).wy + (*(*c).mon).wh / 2 - height(c) / 2;
         }
 
         log::trace!("manage: XWindowChanges");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2423,8 +2423,19 @@ fn manage(w: Window, wa: *mut xlib::XWindowAttributes) {
 
         // TODO pretty sure this doesn't work with pertags, which explains some
         // behavior I saw before in dwm. probably need to operate on
-        // selmon.pertag.tags[selmon.pertag.curtag]
+        // selmon.pertag.tags[selmon.pertag.curtag].
+        //
+        // TODO I'm also pretty sure this is _not_ the right way to be handling
+        // this. checking the name of the window and applying these rules seems
+        // like something meant to be handled by RULES
         (*SELMON).tagset[(*SELMON).seltags as usize] &= !SCRATCHTAG;
+        if libc::strcmp((*c).name.as_ptr(), config::SCRATCHPADNAME) == 0 {
+            (*c).tags = SCRATCHTAG;
+            (*(*c).mon).tagset[(*(*c).mon).seltags as usize] |= (*c).tags;
+            (*c).isfloating = true;
+            (*c).x = (*(*c).mon).wx + (*(*c).mon).ww / 2 - width(c) / 2;
+            (*c).y = (*(*c).mon).wy + (*(*c).mon).wh / 2 - width(c) / 2;
+        }
 
         log::trace!("manage: XWindowChanges");
         let mut wc = xlib::XWindowChanges {


### PR DESCRIPTION
https://dwm.suckless.org/patches/scratchpad/

I also think this one is a bit poorly implemented, with special logic added to `manage` instead of handling the floating and tagging behavior with a `Rule`, but, again, this is the patch I've been using in dwm. It's working in the VM, and we can possibly clean it up later.

As noted in the code, I also think this doesn't work properly with the `pertag` patch, but that should be a relatively straightforward fix to copy any changes to `selmon->tagset` to `selmon->pertag->tags[selmon->pertag->curtag]`. I've been living without that in dwm as well.