### PR TITLE
Add part of the stacker patch

### DIFF
--- a/example.fig
+++ b/example.fig
@@ -55,6 +55,8 @@ let keys = [
 	[MODKEY, XK_b, togglebar, {i: 0}],
 	[MODKEY, XK_j, focusstack, {i: 1}],
 	[MODKEY, XK_k, focusstack, {i: -1}],
+	[S_MOD, XK_j, pushstack, {i: 1}],
+	[S_MOD, XK_k, pushstack, {i: -1}],
 	[MODKEY, XK_i, incnmaster, {i: 1}],
 	[MODKEY, XK_d, incnmaster, {i: -1}],
 	[MODKEY, XK_h, setmfact, {f: -0.05}],

--- a/src/config/fig_env.rs
+++ b/src/config/fig_env.rs
@@ -44,7 +44,7 @@ macro_rules! clicks {
 pub static FIG_ENV: LazyLock<HashMap<String, fig::Value>> = LazyLock::new(
     || {
         let handlers = handler_fns! {
-            focusmon, focusstack, incnmaster, killclient, quit, setlayout, setmfact,
+            focusmon, focusstack, pushstack, incnmaster, killclient, quit, setlayout, setmfact,
             spawn, tag, tagmon, togglebar, togglefloating, toggletag, toggleview,
             view, zoom, movemouse, resizemouse, tile, monocle, fullscreen,
             togglescratch,

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -41,6 +41,7 @@ pub(super) static FUNC_MAP: LazyLock<FnMap> = LazyLock::new(|| {
     HashMap::from([
         ("focusmon", focusmon as FN),
         ("focusstack", focusstack as FN),
+        ("pushstack", pushstack as FN),
         ("incnmaster", incnmaster as FN),
         ("killclient", killclient as FN),
         ("quit", quit as FN),

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -279,9 +279,11 @@ pub(crate) fn togglefloating(_arg: *const Arg) {
     }
 }
 
-/// From the stacker patch. This should only be called with an ISINC arg, in
-/// their parlance, so also inline their stackpos function, in the branch where
-/// this is true
+/// Push clients up (`Arg::I(+N)`) and down (`Arg::I(-N)`) the stack.
+///
+/// From the [stacker patch](https://dwm.suckless.org/patches/stacker/). This
+/// should only be called with an ISINC arg, in their parlance, so also inline
+/// their stackpos function, in the branch where this is true
 pub(crate) fn pushstack(arg: *const Arg) {
     fn modulo(n: c_int, m: c_int) -> c_int {
         if n % m < 0 {

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -310,26 +310,28 @@ pub(crate) fn pushstack(arg: *const Arg) {
         // end stackpos
 
         let sel = (*SELMON).sel;
-        if stackpos < 0 {
-            return;
-        } else if stackpos == 0 {
-            detach(sel);
-            attach(sel);
-        } else {
-            let mut p;
-            cfor!((
-            (p, c) = (null_mut(), (*SELMON).clients);
-            !c.is_null();
-            (p, c) = (c, (*c).next)) {
-                stackpos -= (is_visible(c) && c != sel) as c_int;
-                if stackpos == 0 {
-                    break;
-                }
-            });
-            let c = if !c.is_null() { c } else { p };
-            detach(sel);
-            (*sel).next = (*c).next;
-            (*c).next = sel;
+        match stackpos.cmp(&0) {
+            std::cmp::Ordering::Less => return,
+            std::cmp::Ordering::Equal => {
+                detach(sel);
+                attach(sel);
+            }
+            std::cmp::Ordering::Greater => {
+                let mut p;
+                cfor!((
+                (p, c) = (null_mut(), (*SELMON).clients);
+                !c.is_null();
+                (p, c) = (c, (*c).next)) {
+                    stackpos -= (is_visible(c) && c != sel) as c_int;
+                    if stackpos == 0 {
+                        break;
+                    }
+                });
+                let c = if !c.is_null() { c } else { p };
+                detach(sel);
+                (*sel).next = (*c).next;
+                (*c).next = sel;
+            }
         }
         arrange(SELMON);
     }

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -279,6 +279,62 @@ pub(crate) fn togglefloating(_arg: *const Arg) {
     }
 }
 
+/// From the stacker patch. This should only be called with an ISINC arg, in
+/// their parlance, so also inline their stackpos function, in the branch where
+/// this is true
+pub(crate) fn pushstack(arg: *const Arg) {
+    fn modulo(n: c_int, m: c_int) -> c_int {
+        if n % m < 0 {
+            (n % m) + m
+        } else {
+            n % m
+        }
+    }
+    unsafe {
+        // begin stackpos
+        if (*SELMON).clients.is_null() {
+            return;
+        }
+        if (*SELMON).sel.is_null() {
+            return;
+        }
+        let mut i;
+        let mut c;
+        cfor!((
+            (i, c) = (0, (*SELMON).clients);
+            c != (*SELMON).sel;
+            (i, c) = (i + is_visible(c) as c_int, (*c).next)) {});
+        let mut n;
+        cfor!((n = i; !c.is_null(); (n, c) = (n + is_visible(c) as c_int, (*c).next)) {});
+        let mut stackpos = modulo(i + (*arg).i(), n);
+        // end stackpos
+
+        let sel = (*SELMON).sel;
+        if stackpos < 0 {
+            return;
+        } else if stackpos == 0 {
+            detach(sel);
+            attach(sel);
+        } else {
+            let mut p;
+            cfor!((
+            (p, c) = (null_mut(), (*SELMON).clients);
+            !c.is_null();
+            (p, c) = (c, (*c).next)) {
+                stackpos -= (is_visible(c) && c != sel) as c_int;
+                if stackpos == 0 {
+                    break;
+                }
+            });
+            let c = if !c.is_null() { c } else { p };
+            detach(sel);
+            (*sel).next = (*c).next;
+            (*c).next = sel;
+        }
+        arrange(SELMON);
+    }
+}
+
 pub(crate) fn tag(arg: *const Arg) {
     unsafe {
         if !(*SELMON).sel.is_null() && (*arg).ui() & *TAGMASK != 0 {


### PR DESCRIPTION
This adds the `pushstack` functionality from the [stacker](https://dwm.suckless.org/patches/stacker/) patch, which allows clients to be pushed up and down the stack instead of just sending them to and from the master pane.
![Peek 2024-11-23 14-38](https://github.com/user-attachments/assets/a5f13015-7d52-4309-b7d1-797974bf0a26)
