### PR TITLE
Use Xephyr in automated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ ! matrix.is_mac }}
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ ! matrix.is_mac }}
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr libxcb
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ ! matrix.is_mac }}
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit xorg
           startx
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,3 @@ jobs:
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo test --locked
         run: cargo test --locked --all-features --lib --bins --tests --examples -- --test-threads=1
-      - name: cargo bench
-        run: cargo bench

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |
-          brew install libxft libxinerama
+          brew install libxft libxinerama xquartz
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit xorg
-          echo 'allowed_users = anybody' >> /etc/X11/Xwrapper.config
+          sudo echo 'allowed_users = anybody' >> /etc/X11/Xwrapper.config
           startx
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,11 @@ jobs:
           submodules: true
       - name: Install X libraries (ubuntu)
         if: ${{ ! matrix.is_mac }}
+        # https://unix.stackexchange.com/a/529945/396284
         run: |
           sudo apt-get update
           sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit xorg
+          echo 'allowed_users = anybody' >> /etc/X11/Xwrapper.config
           startx
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ ! matrix.is_mac }}
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr libxcb
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr libxcb1-dev
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,12 @@ jobs:
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |
-          brew install libxft libxinerama xquartz
+          brew install libxft libxinerama
+          brew install --cask xquartz
+          export PATH=$PATH:/opt/X11/bin
+          which xvfb
+          which Xvfb
+          ls /opt/X11
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
         if: ${{ ! matrix.is_mac }}
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit
+          startx
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,9 @@ jobs:
           submodules: true
       - name: Install X libraries (ubuntu)
         if: ${{ ! matrix.is_mac }}
-        # https://unix.stackexchange.com/a/529945/396284
         run: |
           sudo apt-get update
-          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit xorg
-          echo 'allowed_users = anybody' | sudo tee -a /etc/X11/Xwrapper.config
-          startx
+          sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libxft-dev libxinerama-dev xserver-xephyr xinit xorg
-          sudo echo 'allowed_users = anybody' >> /etc/X11/Xwrapper.config
+          echo 'allowed_users = anybody' | sudo tee -a /etc/X11/Xwrapper.config
           startx
       - name: Install X libraries (mac)
         if: ${{ matrix.is_mac }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,7 @@ jobs:
         run: |
           brew install libxft libxinerama
           brew install --cask xquartz
-          export PATH=$PATH:/opt/X11/bin
-          which xvfb
-          which Xvfb
-          ls /opt/X11
+          echo "PATH=$PATH:/opt/X11/bin" >> $GITHUB_ENV
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,39 @@
+use x11::xlib::{XButtonEvent, XEvent, _XDisplay};
+
+pub enum Event {
+    Button(XButtonEvent),
+}
+
+impl Event {
+    pub fn button(
+        window: u64,
+        button: u32,
+        x: i32,
+        display: *mut _XDisplay,
+        state: u32,
+    ) -> Self {
+        Self::Button(XButtonEvent {
+            type_: 0,
+            serial: 0,
+            send_event: 0,
+            display,
+            window,
+            root: 0,
+            subwindow: 0,
+            time: 0,
+            x,
+            y: 0,
+            x_root: 0,
+            y_root: 0,
+            state,
+            button,
+            same_screen: 0,
+        })
+    }
+
+    pub fn into_button(self) -> XEvent {
+        match self {
+            Event::Button(button) => XEvent { button },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::ffi::{c_char, c_int, c_uint};
 use enums::Clk;
 
 pub mod enums;
+pub mod events;
 
 pub type Window = u64;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2932,9 +2932,12 @@ mod tests {
         // goto for killing xephyr no matter what
         let ok = loop {
             unsafe {
-                let Ok((xcon, _)) = Connection::connect(None) else {
-                    eprintln!("rwm: cannot get xcb connection");
-                    break false;
+                let xcon = match Connection::connect(None) {
+                    Ok((xcon, _)) => xcon,
+                    Err(e) => {
+                        eprintln!("rwm: cannot get xcb connection: {e:?}");
+                        break false;
+                    }
                 };
                 XCON = Box::into_raw(Box::new(xcon));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2930,13 +2930,13 @@ mod tests {
         }
 
         // goto for killing xephyr no matter what
-        let ok = loop {
+        let ok = 'defer: {
             unsafe {
                 let xcon = match Connection::connect(Some(":1.0")) {
                     Ok((xcon, _)) => xcon,
                     Err(e) => {
                         eprintln!("rwm: cannot get xcb connection: {e:?}");
-                        break false;
+                        break 'defer false;
                     }
                 };
                 XCON = Box::into_raw(Box::new(xcon));
@@ -2975,7 +2975,8 @@ mod tests {
                 xlib::XCloseDisplay(DPY);
                 drop(Box::from_raw(XCON));
             }
-            break true;
+
+            break 'defer true;
         };
 
         // kill xephyr when finished

--- a/src/main.rs
+++ b/src/main.rs
@@ -2920,7 +2920,8 @@ mod tests {
     #[test]
     fn main() {
         // setup xephyr
-        let mut cmd = Command::new("Xephyr").arg(":1").spawn().unwrap();
+        let mut cmd =
+            Command::new("Xephyr").arg("-ac").arg(":1").spawn().unwrap();
 
         // wait for xephyr to start
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2920,8 +2920,7 @@ mod tests {
     #[test]
     fn main() {
         // setup xephyr
-        let mut cmd =
-            Command::new("Xephyr").arg("-ac").arg(":1").spawn().unwrap();
+        let mut cmd = Command::new("Xvfb").arg(":1").spawn().unwrap();
 
         // wait for xephyr to start
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2932,7 +2932,7 @@ mod tests {
         // goto for killing xephyr no matter what
         let ok = loop {
             unsafe {
-                let xcon = match Connection::connect(None) {
+                let xcon = match Connection::connect(Some(":1.0")) {
                     Ok((xcon, _)) => xcon,
                     Err(e) => {
                         eprintln!("rwm: cannot get xcb connection: {e:?}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2981,6 +2981,7 @@ mod tests {
 
         // kill xephyr when finished
         cmd.kill().unwrap();
+        cmd.try_wait().unwrap();
 
         assert!(ok);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2910,7 +2910,8 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use xlib::{Button1, XButtonEvent, XEvent};
+    use rwm::events::Event;
+    use xlib::Button1;
 
     use super::*;
 
@@ -2945,31 +2946,21 @@ mod tests {
 
             // test that a mouse click on the initial (tiling) layout icon
             // switches to floating mode
-            handlers::buttonpress(&mut XEvent {
-                button: XButtonEvent {
-                    window: (unsafe { *SELMON }).barwin,
-                    button: Button1,
-                    x: CONFIG
+            handlers::buttonpress(
+                &mut Event::button(
+                    (unsafe { *SELMON }).barwin,
+                    Button1,
+                    CONFIG
                         .tags
                         .iter()
                         .map(|tag| textw(tag.as_ptr()))
                         .sum::<i32>()
                         + 5,
-                    display: unsafe { DPY },
-                    state: 0,
-                    // these fields aren't used by `buttonpress`
-                    type_: 0,
-                    serial: 0,
-                    send_event: 0,
-                    root: 0,
-                    subwindow: 0,
-                    time: 0,
-                    y: 0,
-                    x_root: 0,
-                    y_root: 0,
-                    same_screen: 0,
-                },
-            });
+                    unsafe { DPY },
+                    0,
+                )
+                .into_button(),
+            );
             unsafe {
                 assert!((*(*SELMON).lt[(*SELMON).sellt as usize])
                     .arrange

--- a/src/main.rs
+++ b/src/main.rs
@@ -2920,7 +2920,11 @@ mod tests {
     #[test]
     fn main() {
         // setup xephyr
+        #[cfg(target_os = "linux")]
         let mut cmd = Command::new("Xvfb").arg(":1").spawn().unwrap();
+
+        #[cfg(not(target_os = "linux"))]
+        let mut cmd = Command::new("xvfb").arg(":1").spawn().unwrap();
 
         // wait for xephyr to start
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2931,6 +2931,7 @@ mod tests {
 
         // goto for killing xephyr no matter what
         let ok = 'defer: {
+            #[cfg(target_os = "linux")]
             unsafe {
                 let xcon = match Connection::connect(Some(":1.0")) {
                     Ok((xcon, _)) => xcon,
@@ -2973,6 +2974,8 @@ mod tests {
             cleanup();
             unsafe {
                 xlib::XCloseDisplay(DPY);
+
+                #[cfg(target_os = "linux")]
                 drop(Box::from_raw(XCON));
             }
 


### PR DESCRIPTION
This is currently a rough proof-of-concept for running actual tests of the window manager using Xephyr. The example test here is not particularly interesting (checking that clicking the layout icon changes layouts), but the idea of spawning Xephyr and (effectively) calling `main` should be very useful for writing tests.

As noted in the code, the `sleep` call to wait for Xephyr to start isn't great, and both the setup and takedown code should be reused from `main` rather than being copy-pasted from it. Something that isn't even clear from the code is that the `CONFIG` will automatically be loaded from the default config path too, so currently this test could behave differently on different users' machines.

It's also obviously not safe to run more than one of these tests at a time because each test would be mutating the global `DPY`, `XCON`, etc variables. For now, I think it makes sense to have only a single test of this form and have it run through multiple sets of `XEvent`s and corresponding assertions about the WM state.