### PR TITLE
Make `DRW` an option instead of raw pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifdef FIX
 endif
 
 clippy:
-	cargo clippy --workspace --all-targets --all-features $(clippy_args)
+	cargo clippy --workspace --all-targets --all-features --tests $(clippy_args)
 
 doc:
 	cargo doc --open

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -226,26 +226,31 @@ pub(crate) fn setscheme(drw: Option<&mut Drw>, scm: *mut Clr) {
     }
 }
 
-impl Drw {
-    pub(crate) fn fontset_create(&mut self, fonts: &[CString]) -> *mut Fnt {
-        log::trace!("fontset_create");
-        unsafe {
-            let mut ret: *mut Fnt = null_mut();
+pub(crate) fn fontset_create(
+    drw: Option<&mut Drw>,
+    fonts: &[CString],
+) -> *mut Fnt {
+    log::trace!("fontset_create");
+    unsafe {
+        let mut ret: *mut Fnt = null_mut();
 
-            if fonts.is_empty() {
-                return null_mut();
-            }
-
-            for font in fonts.iter().rev() {
-                let cur = xfont_create(self, font.as_ptr(), null_mut());
-                if !cur.is_null() {
-                    (*cur).next = ret;
-                    ret = cur;
-                }
-            }
-            self.fonts = ret;
-            ret
+        // since fonts is a & not a *, it can't be null, but it could be empty
+        let Some(drw) = drw else {
+            return null_mut();
+        };
+        if fonts.is_empty() {
+            return null_mut();
         }
+
+        for font in fonts.iter().rev() {
+            let cur = xfont_create(drw, font.as_ptr(), null_mut());
+            if !cur.is_null() {
+                (*cur).next = ret;
+                ret = cur;
+            }
+        }
+        drw.fonts = ret;
+        ret
     }
 }
 

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -387,13 +387,10 @@ pub(crate) fn fontset_getwidth(
     drw: Option<&mut Drw>,
     text: *const c_char,
 ) -> c_uint {
-    let Some(drw) = drw else {
-        return 0;
-    };
-    if drw.fonts.is_null() || text.is_null() {
+    if drw.as_ref().is_none_or(|drw| drw.fonts.is_null()) || text.is_null() {
         return 0;
     }
-    self::text(Some(drw), 0, 0, 0, 0, 0, text, 0) as c_uint
+    self::text(drw, 0, 0, 0, 0, 0, text, 0) as c_uint
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -194,11 +194,7 @@ pub(crate) fn rect(
     }
 }
 
-pub(crate) fn cur_create(drw: Option<&mut Drw>, shape: c_int) -> *mut Cur {
-    let Some(drw) = drw else {
-        return std::ptr::null_mut();
-    };
-
+pub(crate) fn cur_create(drw: &mut Drw, shape: c_int) -> *mut Cur {
     unsafe {
         let cur: *mut Cur = crate::util::ecalloc(1, size_of::<Cur>()).cast();
         if cur.is_null() {
@@ -226,18 +222,12 @@ pub(crate) fn setscheme(drw: Option<&mut Drw>, scm: *mut Clr) {
     }
 }
 
-pub(crate) fn fontset_create(
-    drw: Option<&mut Drw>,
-    fonts: &[CString],
-) -> *mut Fnt {
+pub(crate) fn fontset_create(drw: &mut Drw, fonts: &[CString]) -> *mut Fnt {
     log::trace!("fontset_create");
     unsafe {
         let mut ret: *mut Fnt = null_mut();
 
         // since fonts is a & not a *, it can't be null, but it could be empty
-        let Some(drw) = drw else {
-            return null_mut();
-        };
         if fonts.is_empty() {
             return null_mut();
         }
@@ -363,14 +353,13 @@ fn clr_create(drw: *mut Drw, dest: *mut Clr, clrname: *const c_char) {
 }
 
 pub(crate) fn scm_create(
-    drw: Option<&mut Drw>,
+    drw: &mut Drw,
     clrnames: &[CString],
     clrcount: usize,
 ) -> *mut Clr {
-    if drw.is_none() || clrnames.is_empty() || clrcount < 2 {
+    if clrnames.is_empty() || clrcount < 2 {
         return null_mut();
     }
-    let drw = drw.unwrap();
     let ret: *mut Clr = ecalloc(clrcount, size_of::<xft::XftColor>()).cast();
     if ret.is_null() {
         return null_mut();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -360,7 +360,7 @@ pub(crate) fn configurenotify(e: *mut XEvent) {
             SW = ev.width;
             SH = ev.height;
             if updategeom() != 0 || dirty {
-                drw::resize(DRW, SW as c_uint, BH as c_uint);
+                drw::resize(DRW.as_mut(), SW as c_uint, BH as c_uint);
                 updatebars();
                 let mut m = MONS;
                 while !m.is_null() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,12 +277,7 @@ fn setup() {
         SH = xlib::XDisplayHeight(DPY, SCREEN);
         ROOT = xlib::XRootWindow(DPY, SCREEN);
         DRW = Some(drw::create(DPY, SCREEN, ROOT, SW as u32, SH as u32));
-        if DRW
-            .as_mut()
-            .unwrap()
-            .fontset_create(&CONFIG.fonts)
-            .is_null()
-        {
+        if drw::fontset_create(DRW.as_mut(), &CONFIG.fonts).is_null() {
             panic!("no fonts could be loaded");
         }
         LRPAD = (*DRW.as_mut().unwrap().fonts).h as i32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,12 +276,13 @@ fn setup() {
         SW = xlib::XDisplayWidth(DPY, SCREEN);
         SH = xlib::XDisplayHeight(DPY, SCREEN);
         ROOT = xlib::XRootWindow(DPY, SCREEN);
-        DRW = Some(drw::create(DPY, SCREEN, ROOT, SW as u32, SH as u32));
-        if drw::fontset_create(DRW.as_mut(), &CONFIG.fonts).is_null() {
+        // DRW = Some();
+        let mut drw = drw::create(DPY, SCREEN, ROOT, SW as u32, SH as u32);
+        if drw::fontset_create(&mut drw, &CONFIG.fonts).is_null() {
             panic!("no fonts could be loaded");
         }
-        LRPAD = (*DRW.as_mut().unwrap().fonts).h as i32;
-        BH = (*DRW.as_mut().unwrap().fonts).h as i32 + 2;
+        LRPAD = (*drw.fonts).h as i32;
+        BH = (*drw.fonts).h as i32 + 2;
         updategeom();
 
         /* init atoms */
@@ -336,18 +337,16 @@ fn setup() {
 
         /* init cursors */
         CURSOR[Cur::Normal as usize] =
-            drw::cur_create(DRW.as_mut(), XC_LEFT_PTR as i32);
+            drw::cur_create(&mut drw, XC_LEFT_PTR as i32);
         CURSOR[Cur::Resize as usize] =
-            drw::cur_create(DRW.as_mut(), XC_SIZING as i32);
-        CURSOR[Cur::Move as usize] =
-            drw::cur_create(DRW.as_mut(), XC_FLEUR as i32);
+            drw::cur_create(&mut drw, XC_SIZING as i32);
+        CURSOR[Cur::Move as usize] = drw::cur_create(&mut drw, XC_FLEUR as i32);
 
         /* init appearance */
         SCHEME =
             util::ecalloc(CONFIG.colors.len(), size_of::<*mut Clr>()).cast();
         for i in 0..CONFIG.colors.len() {
-            *SCHEME.add(i) =
-                drw::scm_create(DRW.as_mut(), &CONFIG.colors[i], 3);
+            *SCHEME.add(i) = drw::scm_create(&mut drw, &CONFIG.colors[i], 3);
         }
 
         // init system tray
@@ -1344,7 +1343,7 @@ fn updatesystray() {
         // redraw background
         XSetForeground(
             DPY,
-            DRW.as_mut().unwrap().gc,
+            DRW.as_ref().unwrap().gc,
             get_scheme_color(SCHEME, Scheme::Norm as usize, Col::Bg as usize)
                 .pixel,
         );


### PR DESCRIPTION
With the reassurance of the new testing changes, this PR starts to remove some of the unsafe in the code base, starting with converting the global `DRW` context from a raw pointer to an `Option<Drw>`. It's obviously annoying to have to `unwrap` (or `let else`) all over the place, but this accurately captures the semantics of all the `is_null` checks in the unsafe case. 