### PR TITLE
Start moving global state into a `State` struct, starting with `Cursor`s

### DIFF
--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ffi::c_uint, sync::LazyLock};
 
 use fig::{FigError, Value};
-use rwm::Arg;
+use rwm::{Arg, State};
 use x11::xlib::KeySym;
 
 #[repr(C)]
@@ -9,7 +9,7 @@ use x11::xlib::KeySym;
 pub struct Key {
     pub mod_: c_uint,
     pub keysym: KeySym,
-    pub func: Option<fn(*const Arg)>,
+    pub func: Option<fn(&State, *const Arg)>,
     pub arg: Arg,
 }
 
@@ -17,7 +17,7 @@ impl Key {
     pub const fn new(
         mod_: c_uint,
         keysym: u32,
-        func: fn(*const Arg),
+        func: fn(&State, *const Arg),
         arg: Arg,
     ) -> Self {
         Self { mod_, keysym: keysym as KeySym, func: Some(func), arg }
@@ -34,10 +34,10 @@ pub(crate) fn conv<T: Clone>(opt: Option<&T>) -> Result<T, FigError> {
     }
 }
 
-type FnMap = HashMap<&'static str, fn(*const Arg)>;
+type FnMap = HashMap<&'static str, fn(&State, *const Arg)>;
 pub(super) static FUNC_MAP: LazyLock<FnMap> = LazyLock::new(|| {
     use crate::key_handlers::*;
-    type FN = fn(*const Arg);
+    type FN = fn(&State, *const Arg);
     HashMap::from([
         ("focusmon", focusmon as FN),
         ("focusstack", focusstack as FN),

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use std::ffi::{c_char, c_int, c_long, c_uchar, c_uint, CStr, CString};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
@@ -113,6 +115,7 @@ fn utf8decode(c: *const i8, u: *mut c_long, clen: usize) -> usize {
     }
 }
 
+/// # Safety
 pub unsafe fn create(
     dpy: *mut Display,
     screen: c_int,
@@ -147,6 +150,7 @@ pub unsafe fn create(
     }
 }
 
+/// # Safety
 pub unsafe fn free(drw: *mut Drw) {
     unsafe {
         xlib::XFreePixmap((*drw).dpy, (*drw).drawable);
@@ -156,7 +160,8 @@ pub unsafe fn free(drw: *mut Drw) {
     }
 }
 
-pub fn rect(
+/// # Safety
+pub unsafe fn rect(
     drw: *mut Drw,
     x: c_int,
     y: c_int,
@@ -202,7 +207,8 @@ pub fn rect(
     }
 }
 
-pub fn cur_create(drw: *mut Drw, shape: c_int) -> Cur {
+/// # Safety
+pub unsafe fn cur_create(drw: *mut Drw, shape: c_int) -> Cur {
     assert!(!drw.is_null());
     unsafe {
         Cur {
@@ -221,7 +227,8 @@ impl Drop for Cur {
     }
 }
 
-pub fn setscheme(drw: *mut Drw, scm: *mut Clr) {
+/// # Safety
+pub unsafe fn setscheme(drw: *mut Drw, scm: *mut Clr) {
     if !drw.is_null() {
         unsafe {
             (*drw).scheme = scm;
@@ -229,6 +236,7 @@ pub fn setscheme(drw: *mut Drw, scm: *mut Clr) {
     }
 }
 
+/// # Safety
 pub unsafe fn fontset_create(drw: *mut Drw, fonts: &[CString]) -> *mut Fnt {
     log::trace!("fontset_create");
     unsafe {
@@ -379,7 +387,8 @@ pub fn scm_create(
     ret
 }
 
-pub fn fontset_getwidth(drw: *mut Drw, text: *const c_char) -> c_uint {
+/// # Safety
+pub unsafe fn fontset_getwidth(drw: *mut Drw, text: *const c_char) -> c_uint {
     unsafe {
         if drw.is_null() || (*drw).fonts.is_null() || text.is_null() {
             return 0;
@@ -389,7 +398,7 @@ pub fn fontset_getwidth(drw: *mut Drw, text: *const c_char) -> c_uint {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn text(
+pub unsafe fn text(
     drw: *mut Drw,
     mut x: c_int,
     y: c_int,
@@ -727,7 +736,7 @@ fn font_getexts(
     }
 }
 
-pub fn map(
+pub unsafe fn map(
     drw: *mut Drw,
     win: Window,
     x: c_int,
@@ -755,7 +764,7 @@ pub fn map(
     }
 }
 
-pub fn resize(drw: *mut Drw, w: c_uint, h: c_uint) {
+pub unsafe fn resize(drw: *mut Drw, w: c_uint, h: c_uint) {
     unsafe {
         if drw.is_null() {
             return;

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -212,13 +212,13 @@ pub fn cur_create(drw: *mut Drw, shape: c_int) -> Cur {
     }
 }
 
-impl Drop for Cur {
-    fn drop(&mut self) {
-        log::trace!("dropping cursor");
-        unsafe {
-            // xlib::XFreeCursor((*self.drw).dpy, self.cursor);
-        }
-        log::trace!("finished dropping cursor");
+pub fn cur_free(drw: *mut Drw, cursor: *mut Cur) {
+    if cursor.is_null() {
+        return;
+    }
+
+    unsafe {
+        xlib::XFreeCursor((*drw).dpy, (*cursor).cursor);
     }
 }
 

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -212,13 +212,13 @@ pub fn cur_create(drw: *mut Drw, shape: c_int) -> Cur {
     }
 }
 
-pub fn cur_free(drw: *mut Drw, cursor: *mut Cur) {
+pub fn cur_free(cursor: *mut Cur) {
     if cursor.is_null() {
         return;
     }
 
     unsafe {
-        xlib::XFreeCursor((*drw).dpy, (*cursor).cursor);
+        xlib::XFreeCursor((*(*cursor).drw).dpy, (*cursor).cursor);
     }
 }
 

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -212,13 +212,12 @@ pub fn cur_create(drw: *mut Drw, shape: c_int) -> Cur {
     }
 }
 
-pub fn cur_free(cursor: *mut Cur) {
-    if cursor.is_null() {
-        return;
-    }
-
-    unsafe {
-        xlib::XFreeCursor((*(*cursor).drw).dpy, (*cursor).cursor);
+impl Drop for Cur {
+    fn drop(&mut self) {
+        unsafe {
+            log::trace!("dropping cur: {}", self.cursor);
+            xlib::XFreeCursor((*self.drw).dpy, self.cursor);
+        }
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -15,14 +15,16 @@ use x11::xlib::{
 };
 
 use rwm::{
+    drw,
     enums::{Col, Scheme, XEmbed},
-    Arg, Client, Monitor, Window,
+    util::ecalloc,
+    Arg, Client, Monitor, State, Window,
 };
 
 use crate::{
     arrange, cleanmask,
     config::CONFIG,
-    configure, drawbar, drawbars, drw,
+    configure, drawbar, drawbars,
     enums::{Clk, Net},
     focus, get_scheme_color, getsystraywidth, grabkeys, height, is_visible,
     manage, recttomon, removesystrayicon, resizebarwin, resizeclient, restack,
@@ -30,7 +32,6 @@ use crate::{
     swallowingclient, textw, unfocus, unmanage, updatebars, updategeom,
     updatesizehints, updatestatus, updatesystray, updatesystrayicongeom,
     updatesystrayiconstate, updatetitle, updatewindowtype, updatewmhints,
-    util::ecalloc,
     width, wintoclient, wintomon, wintosystrayicon,
     xembed::{
         SYSTEM_TRAY_REQUEST_DOCK, XEMBED_EMBEDDED_NOTIFY,
@@ -41,7 +42,7 @@ use crate::{
     SW, SYSTRAY, WITHDRAWN_STATE,
 };
 
-pub(crate) fn buttonpress(e: *mut XEvent) {
+pub(crate) fn buttonpress(state: &State, e: *mut XEvent) {
     unsafe {
         let mut arg = Arg::I(0);
         let ev = &(*e).button;
@@ -104,13 +105,13 @@ pub(crate) fn buttonpress(e: *mut XEvent) {
                 } else {
                     &button.arg
                 };
-                f(a)
+                f(state, a)
             }
         }
     }
 }
 
-pub(crate) fn clientmessage(e: *mut XEvent) {
+pub(crate) fn clientmessage(state: &State, e: *mut XEvent) {
     unsafe {
         let cme = &(*e).client_message;
         let mut c = wintoclient(cme.window);
@@ -273,7 +274,7 @@ pub(crate) fn clientmessage(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn configurerequest(e: *mut XEvent) {
+pub(crate) fn configurerequest(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).configure_request;
         let c = wintoclient(ev.window);
@@ -351,7 +352,7 @@ pub(crate) fn configurerequest(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn configurenotify(e: *mut XEvent) {
+pub(crate) fn configurenotify(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &mut (*e).configure;
         /* TODO: updategeom handling sucks, needs to be simplified */
@@ -361,7 +362,7 @@ pub(crate) fn configurenotify(e: *mut XEvent) {
             SH = ev.height;
             if updategeom() != 0 || dirty {
                 drw::resize(DRW, SW as c_uint, BH as c_uint);
-                updatebars();
+                updatebars(state);
                 let mut m = MONS;
                 while !m.is_null() {
                     let mut c = (*m).clients;
@@ -381,7 +382,7 @@ pub(crate) fn configurenotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn destroynotify(e: *mut XEvent) {
+pub(crate) fn destroynotify(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).destroy_window;
         let mut c = wintoclient(ev.window);
@@ -403,7 +404,7 @@ pub(crate) fn destroynotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn enternotify(e: *mut XEvent) {
+pub(crate) fn enternotify(state: &State, e: *mut XEvent) {
     log::trace!("enternotify");
     unsafe {
         let ev = &mut (*e).crossing;
@@ -424,7 +425,7 @@ pub(crate) fn enternotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn expose(e: *mut XEvent) {
+pub(crate) fn expose(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).expose;
         if ev.count == 0 {
@@ -440,7 +441,7 @@ pub(crate) fn expose(e: *mut XEvent) {
 }
 
 /* there are some broken focus acquiring clients needing extra handling */
-pub(crate) fn focusin(e: *mut XEvent) {
+pub(crate) fn focusin(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).focus_change;
         if !(*SELMON).sel.is_null() && ev.window != (*(*SELMON).sel).win {
@@ -449,7 +450,7 @@ pub(crate) fn focusin(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn keypress(e: *mut XEvent) {
+pub(crate) fn keypress(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &mut (*e).key;
         let keysym = xlib::XKeycodeToKeysym(DPY, ev.keycode as KeyCode, 0);
@@ -458,13 +459,13 @@ pub(crate) fn keypress(e: *mut XEvent) {
                 && cleanmask(key.mod_) == cleanmask(ev.state)
                 && key.func.is_some()
             {
-                key.func.unwrap()(&(key.arg));
+                key.func.unwrap()(state, &(key.arg));
             }
         }
     }
 }
 
-pub(crate) fn mappingnotify(e: *mut XEvent) {
+pub(crate) fn mappingnotify(state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &mut (*e).mapping;
         xlib::XRefreshKeyboardMapping(ev);
@@ -474,7 +475,7 @@ pub(crate) fn mappingnotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn maprequest(e: *mut XEvent) {
+pub(crate) fn maprequest(state: &State, e: *mut XEvent) {
     static mut WA: XWindowAttributes = XWindowAttributes {
         x: 0,
         y: 0,
@@ -534,7 +535,7 @@ pub(crate) fn maprequest(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn motionnotify(e: *mut XEvent) {
+pub(crate) fn motionnotify(state: &State, e: *mut XEvent) {
     log::trace!("motionnotify");
     static mut MON: *mut Monitor = null_mut();
     unsafe {
@@ -552,7 +553,7 @@ pub(crate) fn motionnotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn propertynotify(e: *mut XEvent) {
+pub(crate) fn propertynotify(state: &State, e: *mut XEvent) {
     log::trace!("propertynotify");
     unsafe {
         let mut trans: Window = 0;
@@ -615,7 +616,7 @@ pub(crate) fn propertynotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn unmapnotify(e: *mut XEvent) {
+pub(crate) fn unmapnotify(state: &State, e: *mut XEvent) {
     log::trace!("unmapnotify");
     unsafe {
         let ev = &(*e).unmap;
@@ -639,7 +640,7 @@ pub(crate) fn unmapnotify(e: *mut XEvent) {
     }
 }
 
-pub(crate) fn resizerequest(e: *mut XEvent) {
+pub(crate) fn resizerequest(state: &State, e: *mut XEvent) {
     log::trace!("resizerequest");
     unsafe {
         let ev = &(*e).resize_request;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -111,7 +111,7 @@ pub(crate) fn buttonpress(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn clientmessage(state: &State, e: *mut XEvent) {
+pub(crate) fn clientmessage(_state: &State, e: *mut XEvent) {
     unsafe {
         let cme = &(*e).client_message;
         let mut c = wintoclient(cme.window);
@@ -274,7 +274,7 @@ pub(crate) fn clientmessage(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn configurerequest(state: &State, e: *mut XEvent) {
+pub(crate) fn configurerequest(_state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).configure_request;
         let c = wintoclient(ev.window);
@@ -382,7 +382,7 @@ pub(crate) fn configurenotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn destroynotify(state: &State, e: *mut XEvent) {
+pub(crate) fn destroynotify(_state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).destroy_window;
         let mut c = wintoclient(ev.window);
@@ -404,7 +404,7 @@ pub(crate) fn destroynotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn enternotify(state: &State, e: *mut XEvent) {
+pub(crate) fn enternotify(_state: &State, e: *mut XEvent) {
     log::trace!("enternotify");
     unsafe {
         let ev = &mut (*e).crossing;
@@ -425,7 +425,7 @@ pub(crate) fn enternotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn expose(state: &State, e: *mut XEvent) {
+pub(crate) fn expose(_state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).expose;
         if ev.count == 0 {
@@ -441,7 +441,7 @@ pub(crate) fn expose(state: &State, e: *mut XEvent) {
 }
 
 /* there are some broken focus acquiring clients needing extra handling */
-pub(crate) fn focusin(state: &State, e: *mut XEvent) {
+pub(crate) fn focusin(_state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &(*e).focus_change;
         if !(*SELMON).sel.is_null() && ev.window != (*(*SELMON).sel).win {
@@ -465,7 +465,7 @@ pub(crate) fn keypress(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn mappingnotify(state: &State, e: *mut XEvent) {
+pub(crate) fn mappingnotify(_state: &State, e: *mut XEvent) {
     unsafe {
         let ev = &mut (*e).mapping;
         xlib::XRefreshKeyboardMapping(ev);
@@ -475,7 +475,7 @@ pub(crate) fn mappingnotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn maprequest(state: &State, e: *mut XEvent) {
+pub(crate) fn maprequest(_state: &State, e: *mut XEvent) {
     static mut WA: XWindowAttributes = XWindowAttributes {
         x: 0,
         y: 0,
@@ -535,7 +535,7 @@ pub(crate) fn maprequest(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn motionnotify(state: &State, e: *mut XEvent) {
+pub(crate) fn motionnotify(_state: &State, e: *mut XEvent) {
     log::trace!("motionnotify");
     static mut MON: *mut Monitor = null_mut();
     unsafe {
@@ -553,7 +553,7 @@ pub(crate) fn motionnotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn propertynotify(state: &State, e: *mut XEvent) {
+pub(crate) fn propertynotify(_state: &State, e: *mut XEvent) {
     log::trace!("propertynotify");
     unsafe {
         let mut trans: Window = 0;
@@ -616,7 +616,7 @@ pub(crate) fn propertynotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn unmapnotify(state: &State, e: *mut XEvent) {
+pub(crate) fn unmapnotify(_state: &State, e: *mut XEvent) {
     log::trace!("unmapnotify");
     unsafe {
         let ev = &(*e).unmap;
@@ -640,7 +640,7 @@ pub(crate) fn unmapnotify(state: &State, e: *mut XEvent) {
     }
 }
 
-pub(crate) fn resizerequest(state: &State, e: *mut XEvent) {
+pub(crate) fn resizerequest(_state: &State, e: *mut XEvent) {
     log::trace!("resizerequest");
     unsafe {
         let ev = &(*e).resize_request;

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -188,7 +188,7 @@ pub(crate) fn view(_state: &State, arg: *const Arg) {
             [pertag.curtag as usize][((*SELMON).sellt ^ 1) as usize];
 
         if (*SELMON).showbar != pertag.showbars[pertag.curtag as usize] {
-            togglebar(&_state, null_mut());
+            togglebar(_state, null_mut());
         }
 
         focus(null_mut());
@@ -549,7 +549,7 @@ pub(crate) fn movemouse(state: &State, _arg: *const Arg) {
                         && ((nx - c.x).abs() > CONFIG.snap as c_int
                             || (ny - c.y).abs() > CONFIG.snap as c_int)
                     {
-                        togglefloating(&state, null_mut());
+                        togglefloating(state, null_mut());
                     }
                     if (*(*SELMON).lt[(*SELMON).sellt as usize])
                         .arrange

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -13,17 +13,18 @@ use x11::xlib::{
 };
 
 use crate::config::CONFIG;
-use crate::enums::{Cur, WM};
+use crate::enums::WM;
 use crate::{
     arrange, attach, attachstack, detach, detachstack, drawbar, focus,
     getrootptr, height, is_visible, nexttiled, pop, recttomon, resize,
     resizebarwin, restack, sendevent, setfullscreen, unfocus, updatebarpos,
-    width, xerror, xerrordummy, BH, CURSOR, DPY, HANDLER, MONS, MOUSEMASK,
-    ROOT, SCRATCHTAG, SELMON, SYSTRAY, TAGMASK, WMATOM, XNONE,
+    width, xerror, xerrordummy, BH, DPY, HANDLER, MONS, MOUSEMASK, ROOT,
+    SCRATCHTAG, SELMON, SYSTRAY, TAGMASK, WMATOM, XNONE,
 };
+use rwm::State;
 use rwm::{Arg, Client, Monitor};
 
-pub(crate) fn togglebar(_arg: *const Arg) {
+pub(crate) fn togglebar(_state: &State, _arg: *const Arg) {
     unsafe {
         (*(*SELMON).pertag).showbars[(*(*SELMON).pertag).curtag as usize] =
             !((*SELMON).showbar);
@@ -55,7 +56,7 @@ pub(crate) fn togglebar(_arg: *const Arg) {
     }
 }
 
-pub(crate) fn focusstack(arg: *const Arg) {
+pub(crate) fn focusstack(_state: &State, arg: *const Arg) {
     unsafe {
         let mut c: *mut Client = null_mut();
         let mut i: *mut Client;
@@ -92,7 +93,7 @@ pub(crate) fn focusstack(arg: *const Arg) {
 }
 
 /// Increase the number of windows in the master area.
-pub(crate) fn incnmaster(arg: *const Arg) {
+pub(crate) fn incnmaster(_state: &State, arg: *const Arg) {
     unsafe {
         (*(*SELMON).pertag).nmasters[(*(*SELMON).pertag).curtag as usize] =
             std::cmp::max((*SELMON).nmaster + (*arg).i(), 0);
@@ -106,7 +107,7 @@ pub(crate) fn incnmaster(arg: *const Arg) {
 /// greater than 1.0 sets the fraction absolutely, while fractional values add
 /// to the current value. Total values are restricted to the range [0.05, 0.95]
 /// to leave at least 5% of the screen for other windows.
-pub(crate) fn setmfact(arg: *const Arg) {
+pub(crate) fn setmfact(_state: &State, arg: *const Arg) {
     unsafe {
         if arg.is_null()
             || (*(*SELMON).lt[(*SELMON).sellt as usize]).arrange.is_none()
@@ -130,7 +131,7 @@ pub(crate) fn setmfact(arg: *const Arg) {
 
 /// Move the selected window to the master area. The current master is pushed to
 /// the top of the stack.
-pub(crate) fn zoom(_arg: *const Arg) {
+pub(crate) fn zoom(_state: &State, _arg: *const Arg) {
     unsafe {
         let mut c = (*SELMON).sel;
         if (*(*SELMON).lt[(*SELMON).sellt as usize]).arrange.is_none()
@@ -150,7 +151,7 @@ pub(crate) fn zoom(_arg: *const Arg) {
 }
 
 /// View the tag identified by `arg.ui`.
-pub(crate) fn view(arg: *const Arg) {
+pub(crate) fn view(_state: &State, arg: *const Arg) {
     log::trace!("view");
     unsafe {
         if (*arg).ui() & *TAGMASK
@@ -187,7 +188,7 @@ pub(crate) fn view(arg: *const Arg) {
             [pertag.curtag as usize][((*SELMON).sellt ^ 1) as usize];
 
         if (*SELMON).showbar != pertag.showbars[pertag.curtag as usize] {
-            togglebar(null_mut());
+            togglebar(&_state, null_mut());
         }
 
         focus(null_mut());
@@ -195,7 +196,7 @@ pub(crate) fn view(arg: *const Arg) {
     }
 }
 
-pub(crate) fn killclient(_arg: *const Arg) {
+pub(crate) fn killclient(_state: &State, _arg: *const Arg) {
     unsafe {
         if (*SELMON).sel.is_null() {
             return;
@@ -223,7 +224,7 @@ pub(crate) fn killclient(_arg: *const Arg) {
     }
 }
 
-pub(crate) fn setlayout(arg: *const Arg) {
+pub(crate) fn setlayout(_: &State, arg: *const Arg) {
     log::trace!("setlayout: {arg:?}");
     unsafe {
         if arg.is_null()
@@ -259,7 +260,7 @@ pub(crate) fn setlayout(arg: *const Arg) {
     }
 }
 
-pub(crate) fn togglefloating(_arg: *const Arg) {
+pub(crate) fn togglefloating(_state: &State, _arg: *const Arg) {
     log::trace!("togglefloating: {_arg:?}");
     unsafe {
         if (*SELMON).sel.is_null() {
@@ -284,7 +285,7 @@ pub(crate) fn togglefloating(_arg: *const Arg) {
 /// From the [stacker patch](https://dwm.suckless.org/patches/stacker/). This
 /// should only be called with an ISINC arg, in their parlance, so also inline
 /// their stackpos function, in the branch where this is true
-pub(crate) fn pushstack(arg: *const Arg) {
+pub(crate) fn pushstack(_state: &State, arg: *const Arg) {
     fn modulo(n: c_int, m: c_int) -> c_int {
         if n % m < 0 {
             (n % m) + m
@@ -339,7 +340,7 @@ pub(crate) fn pushstack(arg: *const Arg) {
     }
 }
 
-pub(crate) fn tag(arg: *const Arg) {
+pub(crate) fn tag(_state: &State, arg: *const Arg) {
     unsafe {
         if !(*SELMON).sel.is_null() && (*arg).ui() & *TAGMASK != 0 {
             (*(*SELMON).sel).tags = (*arg).ui() & *TAGMASK;
@@ -367,7 +368,7 @@ fn dirtomon(dir: i32) -> *mut Monitor {
     }
 }
 
-pub(crate) fn focusmon(arg: *const Arg) {
+pub(crate) fn focusmon(_state: &State, arg: *const Arg) {
     unsafe {
         if (*MONS).next.is_null() {
             return;
@@ -401,7 +402,7 @@ fn sendmon(c: *mut Client, m: *mut Monitor) {
     }
 }
 
-pub(crate) fn tagmon(arg: *const Arg) {
+pub(crate) fn tagmon(_state: &State, arg: *const Arg) {
     unsafe {
         if (*SELMON).sel.is_null() || (*MONS).next.is_null() {
             return;
@@ -410,7 +411,7 @@ pub(crate) fn tagmon(arg: *const Arg) {
     }
 }
 
-pub(crate) fn toggleview(arg: *const Arg) {
+pub(crate) fn toggleview(_state: &State, arg: *const Arg) {
     unsafe {
         let newtagset = (*SELMON).tagset[(*SELMON).seltags as usize]
             ^ ((*arg).ui() & *TAGMASK);
@@ -449,7 +450,7 @@ pub(crate) fn toggleview(arg: *const Arg) {
                 != (*(*SELMON).pertag).showbars
                     [(*(*SELMON).pertag).curtag as usize]
             {
-                togglebar(null_mut());
+                togglebar(_state, null_mut());
             }
 
             focus(null_mut());
@@ -458,7 +459,7 @@ pub(crate) fn toggleview(arg: *const Arg) {
     }
 }
 
-pub(crate) fn quit(_arg: *const Arg) {
+pub(crate) fn quit(_state: &State, _arg: *const Arg) {
     unsafe {
         crate::RUNNING = false;
     }
@@ -470,7 +471,7 @@ const EXPOSE: i32 = Expose;
 const MAP_REQUEST: i32 = MapRequest;
 const MOTION_NOTIFY: i32 = MotionNotify;
 
-pub(crate) fn movemouse(_arg: *const Arg) {
+pub(crate) fn movemouse(state: &State, _arg: *const Arg) {
     log::trace!("movemouse");
     unsafe {
         let c = (*SELMON).sel;
@@ -492,7 +493,7 @@ pub(crate) fn movemouse(_arg: *const Arg) {
             GrabModeAsync,
             GrabModeAsync,
             XNONE as u64,
-            (*CURSOR[Cur::Move as usize]).cursor,
+            state.cursors.move_.cursor,
             CurrentTime,
         ) != GrabSuccess
         {
@@ -516,7 +517,7 @@ pub(crate) fn movemouse(_arg: *const Arg) {
             );
             match ev.type_ {
                 CONFIGURE_REQUEST | EXPOSE | MAP_REQUEST => {
-                    HANDLER[ev.type_ as usize](&mut ev);
+                    HANDLER[ev.type_ as usize](state, &mut ev);
                 }
                 MOTION_NOTIFY => {
                     if ev.motion.time - lasttime <= 1000 / 60 {
@@ -548,7 +549,7 @@ pub(crate) fn movemouse(_arg: *const Arg) {
                         && ((nx - c.x).abs() > CONFIG.snap as c_int
                             || (ny - c.y).abs() > CONFIG.snap as c_int)
                     {
-                        togglefloating(null_mut());
+                        togglefloating(&state, null_mut());
                     }
                     if (*(*SELMON).lt[(*SELMON).sellt as usize])
                         .arrange
@@ -574,7 +575,7 @@ pub(crate) fn movemouse(_arg: *const Arg) {
     }
 }
 
-pub(crate) fn resizemouse(_arg: *const Arg) {
+pub(crate) fn resizemouse(state: &State, _arg: *const Arg) {
     log::trace!("resizemouse");
     unsafe {
         let c = (*SELMON).sel;
@@ -596,7 +597,7 @@ pub(crate) fn resizemouse(_arg: *const Arg) {
             GrabModeAsync,
             GrabModeAsync,
             XNONE as u64,
-            (*CURSOR[Cur::Resize as usize]).cursor,
+            state.cursors.resize.cursor,
             CurrentTime,
         ) != GrabSuccess
         {
@@ -626,7 +627,7 @@ pub(crate) fn resizemouse(_arg: *const Arg) {
             );
             match ev.type_ {
                 CONFIGURE_REQUEST | EXPOSE | MAP_REQUEST => {
-                    HANDLER[ev.type_ as usize](&mut ev);
+                    HANDLER[ev.type_ as usize](state, &mut ev);
                 }
                 MOTION_NOTIFY => {
                     if ev.motion.time - lasttime <= 1000 / 60 {
@@ -646,7 +647,7 @@ pub(crate) fn resizemouse(_arg: *const Arg) {
                         && ((nw - c.w).abs() > CONFIG.snap as c_int
                             || (nh - c.h).abs() > CONFIG.snap as c_int)
                     {
-                        togglefloating(null_mut());
+                        togglefloating(state, null_mut());
                     }
                     if (*(*SELMON).lt[(*SELMON).sellt as usize])
                         .arrange
@@ -685,7 +686,7 @@ pub(crate) fn resizemouse(_arg: *const Arg) {
     }
 }
 
-pub(crate) fn spawn(arg: *const Arg) {
+pub(crate) fn spawn(_state: &State, arg: *const Arg) {
     unsafe {
         let mut argv = (*arg).v();
         if argv == *CONFIG.dmenucmd {
@@ -706,7 +707,7 @@ pub(crate) fn spawn(arg: *const Arg) {
 }
 
 /// Move the current window to the tag specified by `arg.ui`.
-pub(crate) fn toggletag(arg: *const Arg) {
+pub(crate) fn toggletag(_state: &State, arg: *const Arg) {
     unsafe {
         if (*SELMON).sel.is_null() {
             return;
@@ -724,7 +725,7 @@ pub(crate) fn toggletag(arg: *const Arg) {
 ///
 /// adapted from: https://old.reddit.com/r/dwm/comments/avhkgb/fullscreen_mode/
 /// for fixing problems with steam games
-pub(crate) fn fullscreen(_: *const Arg) {
+pub(crate) fn fullscreen(_: &State, _: *const Arg) {
     unsafe {
         if (*SELMON).sel.is_null() {
             return;
@@ -733,7 +734,7 @@ pub(crate) fn fullscreen(_: *const Arg) {
     }
 }
 
-pub(crate) fn togglescratch(arg: *const Arg) {
+pub(crate) fn togglescratch(_state: &State, arg: *const Arg) {
     unsafe {
         let mut c: *mut Client;
         let mut found = false;
@@ -759,7 +760,7 @@ pub(crate) fn togglescratch(arg: *const Arg) {
                 restack(SELMON);
             }
         } else {
-            spawn(arg);
+            spawn(_state, arg);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 use std::ffi::{c_char, c_int, c_uint};
 
+use drw::Drw;
 use enums::Clk;
+use x11::xft::XftColor;
 
+pub mod drw;
 pub mod enums;
 pub mod events;
+pub mod util;
 
 pub type Window = u64;
+pub type Clr = XftColor;
 
 #[repr(C)]
 #[derive(Clone, Debug)]
@@ -46,7 +51,7 @@ pub struct Button {
     pub click: c_uint,
     pub mask: c_uint,
     pub button: c_uint,
-    pub func: Option<fn(*const Arg)>,
+    pub func: Option<fn(&State, *const Arg)>,
     pub arg: Arg,
 }
 
@@ -55,7 +60,7 @@ impl Button {
         click: Clk,
         mask: c_uint,
         button: c_uint,
-        func: fn(*const Arg),
+        func: fn(&State, *const Arg),
         arg: Arg,
     ) -> Self {
         Self { click: click as c_uint, mask, button, func: Some(func), arg }
@@ -66,6 +71,7 @@ unsafe impl Sync for Button {}
 
 pub struct Cursor {
     pub cursor: x11::xlib::Cursor,
+    drw: *mut Drw,
 }
 
 #[repr(C)]
@@ -180,4 +186,14 @@ pub struct Client {
     pub swallowing: *mut Client,
     pub mon: *mut Monitor,
     pub win: Window,
+}
+
+pub struct Cursors {
+    pub normal: Cursor,
+    pub resize: Cursor,
+    pub move_: Cursor,
+}
+
+pub struct State {
+    pub cursors: Cursors,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2007,12 +2007,12 @@ fn isuniquegeom(
     }
 }
 
-fn cleanup(state: &mut State) {
+fn cleanup(state: State) {
     log::trace!("entering cleanup");
 
     unsafe {
         let a = Arg::Ui(!0);
-        view(state, &a);
+        view(&state, &a);
         (*SELMON).lt[(*SELMON).sellt as usize] =
             &Layout { symbol: c"".as_ptr(), arrange: None };
 
@@ -2036,9 +2036,8 @@ fn cleanup(state: &mut State) {
             libc::free(SYSTRAY.cast());
         }
 
-        drw::cur_free(&mut state.cursors.move_);
-        drw::cur_free(&mut state.cursors.normal);
-        drw::cur_free(&mut state.cursors.resize);
+        // this needs to be dropped before DRW
+        drop(state);
 
         // free each element in scheme (*mut *mut Clr), then free scheme itself
         for i in 0..CONFIG.colors.len() {
@@ -2900,10 +2899,10 @@ fn main() {
         }
     }
     checkotherwm();
-    let mut state = setup();
+    let state = setup();
     scan();
     run(&state);
-    cleanup(&mut state);
+    cleanup(state);
     unsafe {
         xlib::XCloseDisplay(DPY);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2036,9 +2036,9 @@ fn cleanup(state: &mut State) {
             libc::free(SYSTRAY.cast());
         }
 
-        drw::cur_free(DRW, &mut state.cursors.move_);
-        drw::cur_free(DRW, &mut state.cursors.normal);
-        drw::cur_free(DRW, &mut state.cursors.resize);
+        drw::cur_free(&mut state.cursors.move_);
+        drw::cur_free(&mut state.cursors.normal);
+        drw::cur_free(&mut state.cursors.resize);
 
         // free each element in scheme (*mut *mut Clr), then free scheme itself
         for i in 0..CONFIG.colors.len() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2293,29 +2293,30 @@ fn setclientstate(c: *mut Client, state: usize) {
     }
 }
 
-static HANDLER: LazyLock<
-    [fn(&State, *mut xlib::XEvent); x11::xlib::LASTEvent as usize],
-> = LazyLock::new(|| {
-    fn dh(_state: &State, _ev: *mut xlib::XEvent) {}
-    let mut ret = [dh as fn(state: &State, *mut xlib::XEvent);
-        x11::xlib::LASTEvent as usize];
-    ret[x11::xlib::ButtonPress as usize] = handlers::buttonpress;
-    ret[x11::xlib::ClientMessage as usize] = handlers::clientmessage;
-    ret[x11::xlib::ConfigureRequest as usize] = handlers::configurerequest;
-    ret[x11::xlib::ConfigureNotify as usize] = handlers::configurenotify;
-    ret[x11::xlib::DestroyNotify as usize] = handlers::destroynotify;
-    ret[x11::xlib::EnterNotify as usize] = handlers::enternotify;
-    ret[x11::xlib::Expose as usize] = handlers::expose;
-    ret[x11::xlib::FocusIn as usize] = handlers::focusin;
-    ret[x11::xlib::KeyPress as usize] = handlers::keypress;
-    ret[x11::xlib::MappingNotify as usize] = handlers::mappingnotify;
-    ret[x11::xlib::MapRequest as usize] = handlers::maprequest;
-    ret[x11::xlib::MotionNotify as usize] = handlers::motionnotify;
-    ret[x11::xlib::PropertyNotify as usize] = handlers::propertynotify;
-    ret[x11::xlib::ResizeRequest as usize] = handlers::resizerequest;
-    ret[x11::xlib::UnmapNotify as usize] = handlers::unmapnotify;
-    ret
-});
+type HandlerFn = fn(&State, *mut xlib::XEvent);
+
+static HANDLER: LazyLock<[HandlerFn; x11::xlib::LASTEvent as usize]> =
+    LazyLock::new(|| {
+        fn dh(_state: &State, _ev: *mut xlib::XEvent) {}
+        let mut ret = [dh as fn(state: &State, *mut xlib::XEvent);
+            x11::xlib::LASTEvent as usize];
+        ret[x11::xlib::ButtonPress as usize] = handlers::buttonpress;
+        ret[x11::xlib::ClientMessage as usize] = handlers::clientmessage;
+        ret[x11::xlib::ConfigureRequest as usize] = handlers::configurerequest;
+        ret[x11::xlib::ConfigureNotify as usize] = handlers::configurenotify;
+        ret[x11::xlib::DestroyNotify as usize] = handlers::destroynotify;
+        ret[x11::xlib::EnterNotify as usize] = handlers::enternotify;
+        ret[x11::xlib::Expose as usize] = handlers::expose;
+        ret[x11::xlib::FocusIn as usize] = handlers::focusin;
+        ret[x11::xlib::KeyPress as usize] = handlers::keypress;
+        ret[x11::xlib::MappingNotify as usize] = handlers::mappingnotify;
+        ret[x11::xlib::MapRequest as usize] = handlers::maprequest;
+        ret[x11::xlib::MotionNotify as usize] = handlers::motionnotify;
+        ret[x11::xlib::PropertyNotify as usize] = handlers::propertynotify;
+        ret[x11::xlib::ResizeRequest as usize] = handlers::resizerequest;
+        ret[x11::xlib::UnmapNotify as usize] = handlers::unmapnotify;
+        ret
+    });
 
 /// main event loop
 fn run(state: &State) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,9 +144,6 @@ static mut DRW: *mut Drw = std::ptr::null_mut();
 static mut SELMON: *mut Monitor = std::ptr::null_mut();
 static mut MONS: *mut Monitor = null_mut();
 
-// static mut CURSOR: [*mut Cursor; Cur::Last as usize] =
-//     [null_mut(); Cur::Last as usize];
-
 static mut SCHEME: *mut *mut Clr = null_mut();
 
 fn get_scheme_color(scheme: *mut *mut Clr, i: usize, j: usize) -> Clr {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ fn main() {
             XCON = Box::into_raw(Box::new(xcon));
         }
         checkotherwm();
-        let mut state = setup();
+        let state = setup();
         scan();
 
         // instead of calling `run`, manually send some XEvents
@@ -64,7 +64,7 @@ fn main() {
                 .is_none());
         }
 
-        cleanup(&mut state);
+        cleanup(state);
         unsafe {
             xlib::XCloseDisplay(DPY);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ fn main() {
             XCON = Box::into_raw(Box::new(xcon));
         }
         checkotherwm();
-        setup();
+        let state = setup();
         scan();
 
         // instead of calling `run`, manually send some XEvents
@@ -43,6 +43,7 @@ fn main() {
         // test that a mouse click on the initial (tiling) layout icon
         // switches to floating mode
         handlers::buttonpress(
+            &state,
             &mut Event::button(
                 (unsafe { *SELMON }).barwin,
                 Button1,
@@ -63,7 +64,7 @@ fn main() {
                 .is_none());
         }
 
-        cleanup();
+        cleanup(&state);
         unsafe {
             xlib::XCloseDisplay(DPY);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ fn main() {
             XCON = Box::into_raw(Box::new(xcon));
         }
         checkotherwm();
-        let state = setup();
+        let mut state = setup();
         scan();
 
         // instead of calling `run`, manually send some XEvents
@@ -64,7 +64,7 @@ fn main() {
                 .is_none());
         }
 
-        cleanup(&state);
+        cleanup(&mut state);
         unsafe {
             xlib::XCloseDisplay(DPY);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,12 @@
 use libc::{c_void, size_t};
 
-pub(crate) fn die(msg: &str) -> ! {
+pub fn die(msg: &str) -> ! {
     eprintln!("{}", msg);
     std::process::exit(1);
 }
 
 /// Attempt to allocate with `libc::calloc` and die if the result is null
-pub(crate) fn ecalloc(nmemb: size_t, size: size_t) -> *mut c_void {
+pub fn ecalloc(nmemb: size_t, size: size_t) -> *mut c_void {
     log::trace!("ecalloc: nmemb = {nmemb}, size = {size}");
     let ret = unsafe { libc::calloc(nmemb, size) };
     if ret.is_null() {


### PR DESCRIPTION
These changes start the process of threading a `State` struct through all of the code instead of relying on global mutable statics. `CURSORS` was a pretty easy place to start since it was initialized once and never mutated again. There was some subtlety around where to call `drop`, but otherwise the changes were pretty straightforward.