### PR TITLE
Delete UTF-8 decoding, switch to String

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 clippy_args :=
 ifdef FIX
-    clippy_args += --fix
+    clippy_args += --fix --allow-dirty
 endif
 
 clippy:

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ build: target/release/rwm
 .PHONY: build
 
 xephyr:
-	Xephyr :1 & DISPLAY=:1.0 cargo run && kill %1
+	Xephyr :1 -screen 960x540 & DISPLAY=:1.0 cargo run && kill %1

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -164,7 +164,7 @@ pub fn rect(
     w: c_uint,
     h: c_uint,
     filled: c_int,
-    invert: c_int,
+    invert: bool,
 ) {
     if drw.scheme.is_empty() {
         return;
@@ -174,7 +174,7 @@ pub fn rect(
             drw.dpy,
             drw.gc,
             drw.scheme
-                [if invert != 0 { Col::Bg as usize } else { Col::Fg as usize }]
+                [if invert { Col::Bg as usize } else { Col::Fg as usize }]
             .pixel,
         );
         if filled != 0 {

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -157,9 +157,8 @@ pub fn free(drw: &mut Drw) {
     }
 }
 
-/// # Safety
-pub unsafe fn rect(
-    drw: *mut Drw,
+pub fn rect(
+    drw: &mut Drw,
     x: c_int,
     y: c_int,
     w: c_uint,
@@ -167,35 +166,24 @@ pub unsafe fn rect(
     filled: c_int,
     invert: c_int,
 ) {
+    if drw.scheme.is_empty() {
+        return;
+    }
     unsafe {
-        if drw.is_null() || (*drw).scheme.is_empty() {
-            // TODO can this be &mut Drw?
-            return;
-        }
         xlib::XSetForeground(
-            (*drw).dpy,
-            (*drw).gc,
-            if invert != 0 {
-                (*drw).scheme[Col::Bg as usize].pixel
-            } else {
-                (*drw).scheme[Col::Fg as usize].pixel
-            },
+            drw.dpy,
+            drw.gc,
+            drw.scheme
+                [if invert != 0 { Col::Bg as usize } else { Col::Fg as usize }]
+            .pixel,
         );
         if filled != 0 {
-            xlib::XFillRectangle(
-                (*drw).dpy,
-                (*drw).drawable,
-                (*drw).gc,
-                x,
-                y,
-                w,
-                h,
-            );
+            xlib::XFillRectangle(drw.dpy, drw.drawable, drw.gc, x, y, w, h);
         } else {
             xlib::XDrawRectangle(
-                (*drw).dpy,
-                (*drw).drawable,
-                (*drw).gc,
+                drw.dpy,
+                drw.drawable,
+                drw.gc,
                 x,
                 y,
                 w - 1,

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -466,7 +466,6 @@ pub unsafe fn text(
                             text,
                             utf8charlen as u32,
                             &mut tmpw,
-                            null_mut(),
                         );
                         if ew + ELLIPSIS_WIDTH <= w {
                             // keep track where the ellipsis still fits
@@ -642,13 +641,7 @@ pub unsafe fn text(
     }
 }
 
-fn font_getexts(
-    font: *const Fnt,
-    text: *const i8,
-    len: u32,
-    w: *mut c_uint,
-    h: *mut c_uint,
-) {
+fn font_getexts(font: *const Fnt, text: *const i8, len: u32, w: *mut c_uint) {
     unsafe {
         if font.is_null() || text.is_null() {
             return;
@@ -664,9 +657,6 @@ fn font_getexts(
         let ext = ext.assume_init();
         if !w.is_null() {
             *w = ext.xOff as u32;
-        }
-        if !h.is_null() {
-            *h = (*font).h;
         }
     }
 }

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -382,6 +382,7 @@ pub unsafe fn text(
             // to check if we're at the null byte at the end of the string, NOT
             // if text is a null pointer
             for utf8codepoint in text.chars() {
+                dbg!(&utf8codepoint);
                 utf8charlen = utf8codepoint.len_utf8() as i32;
                 for (font_idx, curfont) in drw.fonts.iter().enumerate() {
                     charexists = charexists
@@ -449,8 +450,8 @@ pub unsafe fn text(
                         drw.fonts[usedfont].xfont,
                         x,
                         ty,
-                        utf8str as *const c_uchar,
-                        utf8strlen,
+                        dbg!(utf8str) as *const c_uchar,
+                        dbg!(utf8strlen),
                     );
                     log::trace!("text: XftDrawStringUtf8 finished");
                 }

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -379,7 +379,7 @@ pub unsafe fn text(
 
         let mut result: xft::FcResult = xft::FcResult::NoMatch;
 
-        let mut charexists: c_int = 0;
+        let mut charexists = false;
         let mut overflow: c_int = 0;
 
         // keep track of a couple codepoints for which we have no match
@@ -449,13 +449,13 @@ pub unsafe fn text(
                 utf8charlen =
                     utf8decode(text, &mut utf8codepoint, UTF_SIZ) as c_int;
                 for (font_idx, curfont) in drw.fonts.iter().enumerate() {
-                    charexists = (charexists != 0
+                    charexists = charexists
                         || xft::XftCharExists(
                             drw.dpy,
                             curfont.xfont,
                             utf8codepoint as u32,
-                        ) != 0) as c_int;
-                    if charexists != 0 {
+                        ) != 0;
+                    if charexists {
                         font_getexts(
                             curfont,
                             text,
@@ -490,12 +490,12 @@ pub unsafe fn text(
                 }
 
                 if overflow != 0
-                    || charexists == 0
+                    || !charexists
                     || nextfont.is_some_and(|n| n < drw.fonts.len())
                 {
                     break;
                 } else {
-                    charexists = 0;
+                    charexists = false;
                 }
             } // end while(*text)
 
@@ -539,12 +539,12 @@ pub unsafe fn text(
             if *text == b'\0' as i8 || overflow != 0 {
                 break;
             } else if nextfont.is_some_and(|n| n < drw.fonts.len()) {
-                charexists = 0;
+                charexists = false;
                 usedfont = nextfont.unwrap();
             } else {
                 // regardless of whether or not a fallback font is found, the
                 // character must be drawn
-                charexists = 1;
+                charexists = true;
 
                 for i in 0..NOMATCHES_LEN {
                     // avoid calling XftFontMatch if we know we won't find a

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -288,15 +288,15 @@ impl Drop for Fnt {
     }
 }
 
-fn clr_create(drw: *const Drw, dest: *mut Clr, clrname: *const c_char) {
-    if drw.is_null() || dest.is_null() || clrname.is_null() {
+fn clr_create(drw: &Drw, dest: *mut Clr, clrname: *const c_char) {
+    if dest.is_null() || clrname.is_null() {
         return;
     }
     unsafe {
         if xft::XftColorAllocName(
-            (*drw).dpy,
-            xlib::XDefaultVisual((*drw).dpy, (*drw).screen),
-            xlib::XDefaultColormap((*drw).dpy, (*drw).screen),
+            drw.dpy,
+            xlib::XDefaultVisual(drw.dpy, drw.screen),
+            xlib::XDefaultColormap(drw.dpy, drw.screen),
             clrname,
             dest,
         ) == 0
@@ -310,12 +310,12 @@ fn clr_create(drw: *const Drw, dest: *mut Clr, clrname: *const c_char) {
 }
 
 pub fn scm_create(
-    drw: *const Drw,
+    drw: &Drw,
     clrnames: &[CString],
     clrcount: usize,
 ) -> Vec<Clr> {
     let mut ret = Vec::new();
-    if drw.is_null() || clrnames.is_empty() || clrcount < 2 {
+    if clrnames.is_empty() || clrcount < 2 {
         return ret;
     }
     for clr in clrnames {

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -672,30 +672,16 @@ fn font_getexts(
 }
 
 pub unsafe fn map(
-    drw: *mut Drw,
+    drw: &Drw,
     win: Window,
     x: c_int,
     y: c_int,
     w: c_uint,
     h: c_uint,
 ) {
-    if drw.is_null() {
-        return;
-    }
     unsafe {
-        xlib::XCopyArea(
-            (*drw).dpy,
-            (*drw).drawable,
-            win,
-            (*drw).gc,
-            x,
-            y,
-            w,
-            h,
-            x,
-            y,
-        );
-        xlib::XSync((*drw).dpy, False);
+        xlib::XCopyArea(drw.dpy, drw.drawable, win, drw.gc, x, y, w, h, x, y);
+        xlib::XSync(drw.dpy, False);
     }
 }
 

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -305,7 +305,7 @@ pub unsafe fn text(
         let mut utf8charlen: c_int;
         let render: c_int = (x != 0 || y != 0 || w != 0 || h != 0) as c_int;
 
-        let utf8codepoint: c_long = 0;
+        let mut utf8codepoint: c_long = 0;
 
         let mut utf8str: *const c_char;
 
@@ -381,9 +381,9 @@ pub unsafe fn text(
             // `while(*text)` to `while !text.is_null()`, but we actually need
             // to check if we're at the null byte at the end of the string, NOT
             // if text is a null pointer
-            for utf8codepoint in text.chars() {
-                dbg!(&utf8codepoint);
-                utf8charlen = utf8codepoint.len_utf8() as i32;
+            for c in text.chars() {
+                utf8codepoint = c as i64;
+                utf8charlen = c.len_utf8() as i32;
                 for (font_idx, curfont) in drw.fonts.iter().enumerate() {
                     charexists = charexists
                         || xft::XftCharExists(
@@ -450,8 +450,8 @@ pub unsafe fn text(
                         drw.fonts[usedfont].xfont,
                         x,
                         ty,
-                        dbg!(utf8str) as *const c_uchar,
-                        dbg!(utf8strlen),
+                        utf8str as *const c_uchar,
+                        utf8strlen,
                     );
                     log::trace!("text: XftDrawStringUtf8 finished");
                 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -58,7 +58,7 @@ pub(crate) fn buttonpress(state: &mut State, e: *mut XEvent) {
             let mut x = 0;
             // emulating do-while
             loop {
-                x += textw(&mut state.drw, CONFIG.tags[i].as_ptr());
+                x += textw(&mut state.drw, &CONFIG.tags[i]);
                 // condition
                 if ev.x < x {
                     break;
@@ -72,15 +72,12 @@ pub(crate) fn buttonpress(state: &mut State, e: *mut XEvent) {
                 click = Clk::TagBar;
                 arg = Arg::Ui(1 << i);
             } else if ev.x
-                < x + textw(
-                    &mut state.drw,
-                    &raw const (*state.selmon).ltsymbol as *const _,
-                )
+                < x + textw(&mut state.drw, &(*state.selmon).ltsymbol)
             {
                 click = Clk::LtSymbol;
             } else if ev.x
                 > (*state.selmon).ww
-                    - textw(&mut state.drw, &raw const state.stext as *const _)
+                    - textw(&mut state.drw, &state.stext)
                     - getsystraywidth() as i32
             {
                 click = Clk::StatusText;

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -258,11 +258,10 @@ pub(crate) fn setlayout(state: &mut State, arg: *const Arg) {
                     [(*state.selmon).pertag.curtag as usize]
                     [(*state.selmon).sellt as usize];
         }
-        libc::strncpy(
-            (*state.selmon).ltsymbol.as_mut_ptr(),
-            (*(*state.selmon).lt[(*state.selmon).sellt as usize]).symbol,
-            size_of_val(&(*state.selmon).ltsymbol),
-        );
+        (*state.selmon).ltsymbol = (*(*state.selmon).lt
+            [(*state.selmon).sellt as usize])
+            .symbol
+            .clone();
         if !(*state.selmon).sel.is_null() {
             arrange(state, state.selmon);
         } else {

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -16,12 +16,7 @@ pub(crate) fn monocle(state: &mut State, m: *mut Monitor) {
         });
         if n > 0 {
             // override layout symbol
-            libc::snprintf(
-                (*m).ltsymbol.as_mut_ptr(),
-                size_of_val(&(*m).ltsymbol),
-                c"[%d]".as_ptr(),
-                n,
-            );
+            (*m).ltsymbol = format!("[{n}]");
         }
         cfor!((c = nexttiled((*m).clients); !c.is_null(); c = nexttiled((*c).next)) {
             resize(state, c, (*m).wx, (*m).wy, (*m).ww - 2 * (*c).bw, (*m).wh - 2 * (*c).bw, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,11 @@ pub struct Cursor {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Rule {
     pub class: *const c_char,
     pub instance: *const c_char,
-    pub title: *const c_char,
+    pub title: String,
     pub tags: c_uint,
     pub isfloating: bool,
     pub isterminal: bool,
@@ -94,9 +94,9 @@ pub struct Systray {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Layout {
-    pub symbol: *const c_char,
+    pub symbol: String,
     pub arrange: Option<fn(&mut State, *mut Monitor)>,
 }
 
@@ -121,7 +121,7 @@ pub struct Pertag {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct Monitor {
-    pub ltsymbol: [c_char; 16usize],
+    pub ltsymbol: String,
     pub mfact: f32,
     pub nmaster: c_int,
     pub num: c_int,
@@ -149,9 +149,9 @@ pub struct Monitor {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Client {
-    pub name: [c_char; 256usize],
+    pub name: String,
     pub mina: f32,
     pub maxa: f32,
     pub x: c_int,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1597,7 +1597,7 @@ fn drawbar(state: &mut State, m: *mut Monitor) {
             }
         }
         drw::map(
-            &mut state.drw,
+            &state.drw,
             (*m).barwin,
             0,
             0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2492,6 +2492,7 @@ fn manage(state: &mut State, w: Window, wa: *mut xlib::XWindowAttributes) {
         (*c).h = wa.height;
         (*c).oldh = wa.height;
         (*c).oldbw = wa.border_width;
+        (*c).name = String::new();
 
         let mut term: *mut Client = null_mut();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 use std::cmp::max;
 use std::ffi::{c_int, c_uint, c_ulong, CStr};
 use std::io::Read;
-use std::mem::size_of_val;
 use std::mem::{size_of, MaybeUninit};
 use std::ptr::null_mut;
 use std::sync::LazyLock;
@@ -1123,9 +1122,7 @@ fn unfocus(state: &mut State, c: *mut Client, setfocus: bool) {
 fn updatestatus(state: &mut State) {
     log::trace!("updatestatus");
     unsafe {
-        let size = size_of_val(&state.stext) as u32;
-        if gettextprop(state.dpy, ROOT, XA_WM_NAME, &mut state.stext, size) == 0
-        {
+        if gettextprop(state.dpy, ROOT, XA_WM_NAME, &mut state.stext) == 0 {
             state.stext = "rwm-1.0".to_string();
         }
         drawbar(state, state.selmon);
@@ -1596,13 +1593,9 @@ fn gettextprop(
     w: Window,
     atom: Atom,
     text: &mut String,
-    size: u32,
 ) -> c_int {
     log::trace!("gettextprop");
     unsafe {
-        if text.is_empty() || size == 0 {
-            return 0;
-        }
         let mut name = xlib::XTextProperty {
             value: std::ptr::null_mut(),
             encoding: 0,
@@ -2892,16 +2885,9 @@ fn updatetitle(state: &mut State, c: *mut Client) {
             (*c).win,
             state.netatom[Net::WMName as usize],
             &mut (*c).name,
-            size_of_val(&(*c).name) as u32,
         ) == 0
         {
-            gettextprop(
-                state.dpy,
-                (*c).win,
-                XA_WM_NAME,
-                &mut (*c).name,
-                size_of_val(&(*c).name) as u32,
-            );
+            gettextprop(state.dpy, (*c).win, XA_WM_NAME, &mut (*c).name);
         }
         if (*c).name.is_empty() {
             /* hack to mark broken clients */

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 //! tiling window manager based on dwm
 
-use std::char::REPLACEMENT_CHARACTER;
 use std::cmp::max;
 use std::ffi::{c_int, c_uint, c_ulong, CStr};
 use std::io::Read;
@@ -1630,16 +1629,16 @@ fn gettextprop(
             // doesn't work for larger characters like ў (cyrillic short u).
             // actually `list` doesn't even contain the right characters for the
             // short u. it just starts at the space after it, as demonstrated by
-            // using libc::printf to try to print it
+            // using libc::printf to try to print it.
+            //
+            // Looks like my encoding is different. Getting 238 in Rust vs 287
+            // in C. Using XGetAtomName shows 238 is UTF8_STRING, while 287 is
+            // _NET_WM_WINDOW_TYPE_POPUP_MENU (??). In dwm in the VM, 287 is
+            // also UTF8_STRING
             *text = String::new();
             let mut c = *list;
             while *c != 0 {
-                text.push(char::from_u32(*c as u8 as u32).unwrap_or_else(
-                    || {
-                        log::error!("failed to decode {}", *c);
-                        REPLACEMENT_CHARACTER
-                    },
-                ));
+                text.push(char::from(*c as u8));
                 c = c.offset(1);
             }
             xlib::XFreeStringList(list);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1525,7 +1525,7 @@ fn drawbar(state: &mut State, m: *mut Monitor) {
                         && !(*state.selmon).sel.is_null()
                         && ((*(*state.selmon).sel).tags & 1 << i) != 0)
                         as c_int,
-                    (urg & 1 << i) as c_int,
+                    (urg & 1 << i) != 0,
                 );
             }
             x += w as i32;
@@ -1577,7 +1577,7 @@ fn drawbar(state: &mut State, m: *mut Monitor) {
                         boxw,
                         boxw,
                         (*(*m).sel).isfixed,
-                        0,
+                        false,
                     );
                 }
             } else {
@@ -1592,7 +1592,7 @@ fn drawbar(state: &mut State, m: *mut Monitor) {
                     w as u32,
                     state.bh as u32,
                     1,
-                    1,
+                    true,
                 );
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,4 @@
-use std::{
-    ffi::{c_char, c_int},
-    ops::Index,
-};
+use std::{ffi::c_int, ops::Index};
 
 use x11::xlib::{self, Atom, Display};
 
@@ -50,7 +47,7 @@ pub struct State {
     pub cursors: Cursors,
     pub selmon: *mut Monitor,
     pub mons: *mut Monitor,
-    pub stext: [c_char; 256],
+    pub stext: String,
     pub scheme: ClrScheme,
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,7 +43,7 @@ fn main() {
             CONFIG
                 .tags
                 .iter()
-                .map(|tag| textw(&mut state.drw, tag.as_ptr()))
+                .map(|tag| textw(&mut state.drw, tag))
                 .sum::<i32>()
                 + 5,
             state.dpy,

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,8 +14,3 @@ pub fn ecalloc(nmemb: size_t, size: size_t) -> *mut c_void {
     }
     ret
 }
-
-#[inline]
-pub(crate) fn between<T: PartialOrd>(x: T, a: T, b: T) -> bool {
-    a <= x && x <= b
-}


### PR DESCRIPTION
This went surprisingly well except for an infuriating issue in `gettextprop` that I still haven't resolved. For some reason `XmbTextPropertyToTextList` returns a different sequence of characters in dwm, which allows characters like `ў` (cyrillic short u) to be displayed in window titles. Here, `*list` doesn't even contain the components of these characters. Still, this fixed an existing bug in rwm that truncated the title at the first unrecognized entry. That one exists even in the 1.0 build, but I never noticed it. So between simplifying the complicated UTF-8 handling and resolving part of that bug, I'm very happy with these changes.