### PR TITLE
Fix `sendevent` so `killclient` only kills the focused window

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -524,8 +524,8 @@ pub fn sendevent(
             if xlib::XGetWMProtocols(state.dpy, w, &mut protocols, &mut n) != 0
             {
                 while exists == 0 && n > 0 {
-                    exists = (*protocols.offset(n as isize) == proto) as c_int;
                     n -= 1;
+                    exists = (*protocols.offset(n as isize) == proto) as c_int;
                 }
                 XFree(protocols.cast());
             }


### PR DESCRIPTION
Fixes #51.

Apparently I've been indexing beyond the contents of `protocols` this whole time by not decrementing `n` before using it as an offset. When bisecting, 7b9e31a  was the first bad commit, but `killclient` itself is fine, it just used my faulty `sendevent` implementation.