### PR TITLE
Refactor some bools

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -467,7 +467,7 @@ pub fn drawbars(state: &mut State) {
 pub fn setfocus(state: &mut State, c: *mut Client) {
     log::trace!("setfocus");
     unsafe {
-        if (*c).neverfocus == 0 {
+        if !(*c).neverfocus {
             xlib::XSetInputFocus(
                 state.dpy,
                 (*c).win,
@@ -2637,9 +2637,9 @@ pub fn updatewmhints(state: &mut State, c: *mut Client) {
                 (*c).isurgent = ((*wmh).flags & URGENT != 0) as bool;
             }
             if (*wmh).flags & InputHint != 0 {
-                (*c).neverfocus = ((*wmh).input == 0) as c_int;
+                (*c).neverfocus = (*wmh).input == 0;
             } else {
-                (*c).neverfocus = 0;
+                (*c).neverfocus = false;
             }
             xlib::XFree(wmh.cast());
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -845,7 +845,7 @@ pub fn applysizehints(
                 .arrange
                 .is_none()
         {
-            if (*c).hintsvalid == 0 {
+            if !(*c).hintsvalid {
                 updatesizehints(state, c);
             }
             /* see last two sentences in ICCCM 4.1.2.3 */
@@ -967,7 +967,7 @@ pub fn updatesizehints(state: &mut State, c: *mut Client) {
             && (*c).maxh != 0
             && (*c).maxw == (*c).minw
             && (*c).maxh == (*c).minh;
-        (*c).hintsvalid = 1;
+        (*c).hintsvalid = true;
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -963,10 +963,10 @@ pub fn updatesizehints(state: &mut State, c: *mut Client) {
             (*c).maxa = 0.0;
         }
 
-        (*c).isfixed = ((*c).maxw != 0
+        (*c).isfixed = (*c).maxw != 0
             && (*c).maxh != 0
             && (*c).maxw == (*c).minw
-            && (*c).maxh == (*c).minh) as c_int;
+            && (*c).maxh == (*c).minh;
         (*c).hintsvalid = 1;
     }
 }
@@ -1489,10 +1489,9 @@ pub fn drawbar(state: &mut State, m: *mut Monitor) {
                     boxs as i32,
                     boxw,
                     boxw,
-                    (m == state.selmon
+                    m == state.selmon
                         && !(*state.selmon).sel.is_null()
-                        && ((*(*state.selmon).sel).tags & (1 << i)) != 0)
-                        as c_int,
+                        && ((*(*state.selmon).sel).tags & (1 << i)) != 0,
                     (urg & (1 << i)) != 0,
                 );
             }
@@ -1559,7 +1558,7 @@ pub fn drawbar(state: &mut State, m: *mut Monitor) {
                     0,
                     w as u32,
                     state.bh as u32,
-                    1,
+                    true,
                     true,
                 );
             }
@@ -2584,7 +2583,7 @@ pub fn manage(state: &mut State, w: Window, wa: *mut xlib::XWindowAttributes) {
         );
         grabbuttons(state, c, false);
         if !(*c).isfloating {
-            (*c).oldstate = trans != 0 || (*c).isfixed != 0;
+            (*c).oldstate = trans != 0 || (*c).isfixed;
             (*c).isfloating = (*c).oldstate;
         }
         if (*c).isfloating {

--- a/src/core.rs
+++ b/src/core.rs
@@ -699,7 +699,7 @@ pub fn resize(
     interact: c_int,
 ) {
     log::trace!("resize");
-    if applysizehints(state, c, &mut x, &mut y, &mut w, &mut h, interact) != 0 {
+    if applysizehints(state, c, &mut x, &mut y, &mut w, &mut h, interact) {
         resizeclient(state, c, x, y, w, h);
     }
 }
@@ -798,7 +798,7 @@ pub fn applysizehints(
     w: &mut i32,
     h: &mut i32,
     interact: c_int,
-) -> c_int {
+) -> bool {
     log::trace!("applysizehints");
     unsafe {
         let m = (*c).mon;
@@ -885,7 +885,7 @@ pub fn applysizehints(
                 *h = std::cmp::min(*h, (*c).maxh);
             }
         }
-        (*x != (*c).x || *y != (*c).y || *w != (*c).w || *h != (*c).h) as c_int
+        *x != (*c).x || *y != (*c).y || *w != (*c).w || *h != (*c).h
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -426,7 +426,7 @@ pub unsafe fn focus(state: &mut State, mut c: *mut Client) {
             if (*c).mon != state.selmon {
                 state.selmon = (*c).mon;
             }
-            if (*c).isurgent != 0 {
+            if (*c).isurgent {
                 seturgent(state, c, false);
             }
             detachstack(c);
@@ -1067,7 +1067,7 @@ pub fn updatenumlockmask(state: &mut State) {
 pub fn seturgent(state: &mut State, c: *mut Client, urg: bool) {
     log::trace!("seturgent");
     unsafe {
-        (*c).isurgent = urg as c_int;
+        (*c).isurgent = urg;
         let wmh = xlib::XGetWMHints(state.dpy, (*c).win);
         if wmh.is_null() {
             return;
@@ -1449,7 +1449,7 @@ pub fn drawbar(state: &mut State, m: *mut Monitor) {
         let mut c = (*m).clients;
         while !c.is_null() {
             occ |= (*c).tags;
-            if (*c).isurgent != 0 {
+            if (*c).isurgent {
                 urg |= (*c).tags;
             }
             c = (*c).next;
@@ -2635,7 +2635,7 @@ pub fn updatewmhints(state: &mut State, c: *mut Client) {
                 (*wmh).flags &= !URGENT;
                 xlib::XSetWMHints(state.dpy, (*c).win, wmh);
             } else {
-                (*c).isurgent = ((*wmh).flags & URGENT != 0) as bool as c_int;
+                (*c).isurgent = ((*wmh).flags & URGENT != 0) as bool;
             }
             if (*wmh).flags & InputHint != 0 {
                 (*c).neverfocus = ((*wmh).input == 0) as c_int;

--- a/src/core.rs
+++ b/src/core.rs
@@ -510,23 +510,23 @@ pub fn sendevent(
     d2: c_long,
     d3: c_long,
     d4: c_long,
-) -> c_int {
+) -> bool {
     log::trace!("sendevent");
     let mt;
-    let mut exists = 0;
+    let mut exists = false;
     unsafe {
         if proto == state.wmatom[WM::TakeFocus as usize]
             || proto == state.wmatom[WM::Delete as usize]
         {
             mt = state.wmatom[WM::Protocols as usize];
             if let Ok(protocols) = x::get_wm_protocols(state.dpy, w) {
-                exists = protocols.iter().rev().any(|p| *p == proto) as c_int;
+                exists = protocols.iter().rev().any(|p| *p == proto);
             }
         } else {
-            exists = 1;
+            exists = true;
             mt = proto;
         }
-        if exists != 0 {
+        if exists {
             let mut ev = xlib::XEvent { type_: ClientMessage };
             ev.client_message.window = w;
             ev.client_message.message_type = mt;

--- a/src/drw.rs
+++ b/src/drw.rs
@@ -95,7 +95,7 @@ pub fn rect(
     y: c_int,
     w: c_uint,
     h: c_uint,
-    filled: c_int,
+    filled: bool,
     invert: bool,
 ) {
     if drw.scheme.is_empty() {
@@ -109,7 +109,7 @@ pub fn rect(
                 [if invert { Col::Bg as usize } else { Col::Fg as usize }]
             .pixel,
         );
-        if filled != 0 {
+        if filled {
             xlib::XFillRectangle(drw.dpy, drw.drawable, drw.gc, x, y, w, h);
         } else {
             xlib::XDrawRectangle(

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -274,7 +274,7 @@ pub(crate) fn clientmessage(state: &mut State, e: *mut XEvent) {
             }
         } else if cme.message_type == state.netatom[Net::ActiveWindow as usize]
             && c != (*state.selmon).sel
-            && (*c).isurgent == 0
+            && !(*c).isurgent
         {
             seturgent(state, c, true);
         }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -624,7 +624,7 @@ pub(crate) fn propertynotify(state: &mut State, e: *mut XEvent) {
                     }
                 }
                 XA_WM_NORMAL_HINTS => {
-                    c.hintsvalid = 0;
+                    c.hintsvalid = false;
                 }
                 XA_WM_HINTS => {
                     updatewmhints(state, c);

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -214,7 +214,7 @@ pub(crate) fn killclient(state: &mut State, _arg: *const Arg) {
             return;
         }
 
-        if sendevent(
+        if !sendevent(
             state,
             (*(*state.selmon).sel).win,
             state.wmatom[WM::Delete as usize],
@@ -224,8 +224,7 @@ pub(crate) fn killclient(state: &mut State, _arg: *const Arg) {
             0,
             0,
             0,
-        ) == 0
-        {
+        ) {
             XGrabServer(state.dpy);
             XSetErrorHandler(Some(xerrordummy));
             XSetCloseDownMode(state.dpy, DestroyAll);

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -284,7 +284,7 @@ pub(crate) fn togglefloating(state: &mut State, _arg: *const Arg) {
             return;
         }
         (*(*state.selmon).sel).isfloating = !(*(*state.selmon).sel).isfloating
-            || (*(*state.selmon).sel).isfixed != 0;
+            || (*(*state.selmon).sel).isfixed;
         if (*(*state.selmon).sel).isfloating {
             let sel = &mut *(*state.selmon).sel;
             resize(state, sel, sel.x, sel.y, sel.w, sel.h, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub struct Client {
     pub isfixed: bool,
     pub isfloating: bool,
     pub isurgent: bool,
-    pub neverfocus: c_int,
+    pub neverfocus: bool,
     pub oldstate: bool,
     pub isfullscreen: bool,
     pub isterminal: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ pub struct Client {
     pub tags: c_uint,
     pub isfixed: c_int,
     pub isfloating: bool,
-    pub isurgent: c_int,
+    pub isurgent: bool,
     pub neverfocus: c_int,
     pub oldstate: bool,
     pub isfullscreen: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,6 @@ impl Button {
     }
 }
 
-unsafe impl Sync for Button {}
-
 pub struct Cursor {
     pub cursor: x11::xlib::Cursor,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ pub struct Client {
     pub bw: c_int,
     pub oldbw: c_int,
     pub tags: c_uint,
-    pub isfixed: c_int,
+    pub isfixed: bool,
     pub isfloating: bool,
     pub isurgent: bool,
     pub neverfocus: c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub struct Client {
     pub maxh: c_int,
     pub minw: c_int,
     pub minh: c_int,
-    pub hintsvalid: c_int,
+    pub hintsvalid: bool,
     pub bw: c_int,
     pub oldbw: c_int,
     pub tags: c_uint,


### PR DESCRIPTION
I started out with `sendevent` and then fixed a few more `c_int`s being used for their boolean values. While doing so, I also noticed that the unsafe `Sync` impl for `Button` is no longer needed.