### PR TITLE
Use usize directly for some fields

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -613,8 +613,8 @@ pub fn arrange(state: &mut State, mut m: *mut Monitor) {
 pub fn arrangemon(state: &mut State, m: *mut Monitor) {
     log::trace!("arrangemon");
     unsafe {
-        (*m).ltsymbol = (*(*m).lt[(*m).sellt as usize]).symbol.clone();
-        let arrange = &(*(*m).lt[(*m).sellt as usize]).arrange;
+        (*m).ltsymbol = (*(*m).lt[(*m).sellt]).symbol.clone();
+        let arrange = &(*(*m).lt[(*m).sellt]).arrange;
         if let Some(arrange) = arrange {
             (arrange.0)(state, m);
         }
@@ -628,12 +628,10 @@ pub fn restack(state: &mut State, m: *mut Monitor) {
         if (*m).sel.is_null() {
             return;
         }
-        if (*(*m).sel).isfloating
-            || (*(*m).lt[(*m).sellt as usize]).arrange.is_none()
-        {
+        if (*(*m).sel).isfloating || (*(*m).lt[(*m).sellt]).arrange.is_none() {
             xlib::XRaiseWindow(state.dpy, (*(*m).sel).win);
         }
-        if (*(*m).lt[(*m).sellt as usize]).arrange.is_some() {
+        if (*(*m).lt[(*m).sellt]).arrange.is_some() {
             let mut wc = xlib::XWindowChanges {
                 stack_mode: Below,
                 sibling: (*m).barwin,
@@ -672,9 +670,7 @@ pub fn showhide(state: &mut State, c: *mut Client) {
         if is_visible(c) {
             // show clients top down
             xlib::XMoveWindow(state.dpy, (*c).win, (*c).x, (*c).y);
-            if ((*(*(*c).mon).lt[(*(*c).mon).sellt as usize])
-                .arrange
-                .is_none()
+            if ((*(*(*c).mon).lt[(*(*c).mon).sellt]).arrange.is_none()
                 || (*c).isfloating)
                 && !(*c).isfullscreen
             {
@@ -841,9 +837,7 @@ pub fn applysizehints(
         }
         if state.config.resize_hints
             || (*c).isfloating
-            || (*(*(*c).mon).lt[(*(*c).mon).sellt as usize])
-                .arrange
-                .is_none()
+            || (*(*(*c).mon).lt[(*(*c).mon).sellt]).arrange.is_none()
         {
             if !(*c).hintsvalid {
                 updatesizehints(state, c);
@@ -1461,9 +1455,7 @@ pub fn drawbar(state: &mut State, m: *mut Monitor) {
             let w = textw(&mut state.drw, &text, state.lrpad);
             drw::setscheme(
                 &mut state.drw,
-                state.scheme[if ((*m).tagset[(*m).seltags as usize] & (1 << i))
-                    != 0
-                {
+                state.scheme[if ((*m).tagset[(*m).seltags] & (1 << i)) != 0 {
                     Scheme::Sel
                 } else {
                     Scheme::Norm
@@ -2030,9 +2022,7 @@ pub fn detachstack(c: *mut Client) {
 /// as close as I can get
 #[inline]
 pub fn is_visible(c: *const Client) -> bool {
-    unsafe {
-        ((*c).tags & (*(*c).mon).tagset[(*(*c).mon).seltags as usize]) != 0
-    }
+    unsafe { ((*c).tags & (*(*c).mon).tagset[(*(*c).mon).seltags]) != 0 }
 }
 
 pub fn updatebarpos(state: &mut State, m: *mut Monitor) {
@@ -2080,7 +2070,7 @@ pub fn cleanup(mut state: State) {
     unsafe {
         let a = Arg::Ui(!0);
         view(&mut state, &a);
-        (*state.selmon).lt[(*state.selmon).sellt as usize] =
+        (*state.selmon).lt[(*state.selmon).sellt] =
             &Layout { symbol: String::new(), arrange: None };
 
         let mut m = state.mons;
@@ -2535,11 +2525,10 @@ pub fn manage(state: &mut State, w: Window, wa: *mut xlib::XWindowAttributes) {
         // TODO I'm also pretty sure this is _not_ the right way to be handling
         // this. checking the name of the window and applying these rules seems
         // like something meant to be handled by RULES
-        (*state.selmon).tagset[(*state.selmon).seltags as usize] &=
-            !state.scratchtag();
+        (*state.selmon).tagset[(*state.selmon).seltags] &= !state.scratchtag();
         if (*c).name == state.config.scratchpadname {
             (*c).tags = state.scratchtag();
-            (*(*c).mon).tagset[(*(*c).mon).seltags as usize] |= (*c).tags;
+            (*(*c).mon).tagset[(*(*c).mon).seltags] |= (*c).tags;
             (*c).isfloating = true;
             (*c).x = (*(*c).mon).wx + (*(*c).mon).ww / 2 - width(c) / 2;
             (*c).y = (*(*c).mon).wy + (*(*c).mon).wh / 2 - height(c) / 2;
@@ -2828,7 +2817,7 @@ pub fn applyrules(state: &mut State, c: *mut Client) {
         (*c).tags = if (*c).tags & state.tagmask() != 0 {
             (*c).tags & state.tagmask()
         } else {
-            (*(*c).mon).tagset[(*(*c).mon).seltags as usize]
+            (*(*c).mon).tagset[(*(*c).mon).seltags]
         };
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -289,7 +289,7 @@ pub(crate) fn configurerequest(state: &mut State, e: *mut XEvent) {
             if (ev.value_mask & CWBorderWidth as u64) != 0 {
                 (*c).bw = ev.border_width;
             } else if (*c).isfloating
-                || (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+                || (*(*state.selmon).lt[(*state.selmon).sellt])
                     .arrange
                     .is_none()
             {

--- a/src/key_handlers.rs
+++ b/src/key_handlers.rs
@@ -25,10 +25,8 @@ use crate::{Arg, Client, Monitor};
 pub(crate) fn togglebar(state: &mut State, _arg: *const Arg) {
     unsafe {
         let monitor = &mut *state.selmon;
-        monitor.pertag.showbars[monitor.pertag.curtag as usize] =
-            !monitor.showbar;
-        monitor.showbar =
-            monitor.pertag.showbars[monitor.pertag.curtag as usize];
+        monitor.pertag.showbars[monitor.pertag.curtag] = !monitor.showbar;
+        monitor.showbar = monitor.pertag.showbars[monitor.pertag.curtag];
         updatebarpos(state, state.selmon);
         resizebarwin(state, state.selmon);
         if state.config.showsystray {
@@ -101,10 +99,9 @@ pub(crate) fn focusstack(state: &mut State, arg: *const Arg) {
 pub(crate) fn incnmaster(state: &mut State, arg: *const Arg) {
     unsafe {
         let monitor = &mut *state.selmon;
-        monitor.pertag.nmasters[monitor.pertag.curtag as usize] =
+        monitor.pertag.nmasters[monitor.pertag.curtag] =
             std::cmp::max(monitor.nmaster + (*arg).i(), 0);
-        monitor.nmaster =
-            monitor.pertag.nmasters[monitor.pertag.curtag as usize];
+        monitor.nmaster = monitor.pertag.nmasters[monitor.pertag.curtag];
         arrange(state, state.selmon);
     }
 }
@@ -116,7 +113,7 @@ pub(crate) fn incnmaster(state: &mut State, arg: *const Arg) {
 pub(crate) fn setmfact(state: &mut State, arg: *const Arg) {
     unsafe {
         if arg.is_null()
-            || (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+            || (*(*state.selmon).lt[(*state.selmon).sellt])
                 .arrange
                 .is_none()
         {
@@ -131,8 +128,8 @@ pub(crate) fn setmfact(state: &mut State, arg: *const Arg) {
             return;
         }
         let monitor = &mut *state.selmon;
-        monitor.pertag.mfacts[monitor.pertag.curtag as usize] = f;
-        monitor.mfact = monitor.pertag.mfacts[monitor.pertag.curtag as usize];
+        monitor.pertag.mfacts[monitor.pertag.curtag] = f;
+        monitor.mfact = monitor.pertag.mfacts[monitor.pertag.curtag];
         arrange(state, state.selmon);
     }
 }
@@ -142,7 +139,7 @@ pub(crate) fn setmfact(state: &mut State, arg: *const Arg) {
 pub(crate) fn zoom(state: &mut State, _arg: *const Arg) {
     unsafe {
         let mut c = (*state.selmon).sel;
-        if (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+        if (*(*state.selmon).lt[(*state.selmon).sellt])
             .arrange
             .is_none()
             || c.is_null()
@@ -165,7 +162,7 @@ pub(crate) fn view(state: &mut State, arg: *const Arg) {
     log::trace!("view");
     unsafe {
         if (*arg).ui() & state.tagmask()
-            == (*state.selmon).tagset[(*state.selmon).seltags as usize]
+            == (*state.selmon).tagset[(*state.selmon).seltags]
         {
             return;
         }
@@ -174,7 +171,7 @@ pub(crate) fn view(state: &mut State, arg: *const Arg) {
         // Safety: we were gonna dereference it anyway
         let pertag = &mut (*state.selmon).pertag;
         if ((*arg).ui() & state.tagmask()) != 0 {
-            (*state.selmon).tagset[(*state.selmon).seltags as usize] =
+            (*state.selmon).tagset[(*state.selmon).seltags] =
                 (*arg).ui() & state.tagmask();
             pertag.prevtag = pertag.curtag;
 
@@ -189,16 +186,15 @@ pub(crate) fn view(state: &mut State, arg: *const Arg) {
             std::mem::swap(&mut pertag.prevtag, &mut pertag.curtag);
         }
 
-        (*state.selmon).nmaster = pertag.nmasters[pertag.curtag as usize];
-        (*state.selmon).mfact = pertag.mfacts[pertag.curtag as usize];
-        (*state.selmon).sellt = pertag.sellts[pertag.curtag as usize];
-        (*state.selmon).lt[(*state.selmon).sellt as usize] = pertag.ltidxs
-            [pertag.curtag as usize][(*state.selmon).sellt as usize];
-        (*state.selmon).lt[((*state.selmon).sellt ^ 1) as usize] = pertag
-            .ltidxs[pertag.curtag as usize]
-            [((*state.selmon).sellt ^ 1) as usize];
+        (*state.selmon).nmaster = pertag.nmasters[pertag.curtag];
+        (*state.selmon).mfact = pertag.mfacts[pertag.curtag];
+        (*state.selmon).sellt = pertag.sellts[pertag.curtag];
+        (*state.selmon).lt[(*state.selmon).sellt] =
+            pertag.ltidxs[pertag.curtag][(*state.selmon).sellt];
+        (*state.selmon).lt[(*state.selmon).sellt ^ 1] =
+            pertag.ltidxs[pertag.curtag][(*state.selmon).sellt ^ 1];
 
-        if (*state.selmon).showbar != pertag.showbars[pertag.curtag as usize] {
+        if (*state.selmon).showbar != pertag.showbars[pertag.curtag] {
             togglebar(state, null_mut());
         }
 
@@ -243,21 +239,19 @@ pub(crate) fn setlayout(state: &mut State, arg: *const Arg) {
             || (*arg).l().is_none()
             || !std::ptr::eq(
                 &state.config.layouts[(*arg).l().unwrap()],
-                monitor.lt[monitor.sellt as usize],
+                monitor.lt[monitor.sellt],
             )
         {
-            monitor.pertag.sellts[monitor.pertag.curtag as usize] ^= 1;
-            monitor.sellt =
-                monitor.pertag.sellts[monitor.pertag.curtag as usize];
+            monitor.pertag.sellts[monitor.pertag.curtag] ^= 1;
+            monitor.sellt = monitor.pertag.sellts[monitor.pertag.curtag];
         }
         if !arg.is_null() && (*arg).l().is_some() {
-            monitor.pertag.ltidxs[monitor.pertag.curtag as usize]
-                [monitor.sellt as usize] =
+            monitor.pertag.ltidxs[monitor.pertag.curtag][monitor.sellt] =
                 &state.config.layouts[(*arg).l().unwrap()];
-            monitor.lt[monitor.sellt as usize] = monitor.pertag.ltidxs
-                [monitor.pertag.curtag as usize][monitor.sellt as usize];
+            monitor.lt[monitor.sellt] =
+                monitor.pertag.ltidxs[monitor.pertag.curtag][monitor.sellt];
         }
-        monitor.ltsymbol = (*monitor.lt[monitor.sellt as usize]).symbol.clone();
+        monitor.ltsymbol = (*monitor.lt[monitor.sellt]).symbol.clone();
         if !monitor.sel.is_null() {
             arrange(state, state.selmon);
         } else {
@@ -401,7 +395,7 @@ fn sendmon(state: &mut State, c: *mut Client, m: *mut Monitor) {
         detachstack(c);
         (*c).mon = m;
         // assign tags of target monitor
-        (*c).tags = (*m).tagset[(*m).seltags as usize];
+        (*c).tags = (*m).tagset[(*m).seltags];
         attach(c);
         attachstack(c);
         focus(state, null_mut());
@@ -421,11 +415,11 @@ pub(crate) fn tagmon(state: &mut State, arg: *const Arg) {
 pub(crate) fn toggleview(state: &mut State, arg: *const Arg) {
     unsafe {
         let monitor = &mut *state.selmon;
-        let newtagset = monitor.tagset[monitor.seltags as usize]
-            ^ ((*arg).ui() & state.tagmask());
+        let newtagset =
+            monitor.tagset[monitor.seltags] ^ ((*arg).ui() & state.tagmask());
 
         if newtagset != 0 {
-            monitor.tagset[monitor.seltags as usize] = newtagset;
+            monitor.tagset[monitor.seltags] = newtagset;
 
             if newtagset == !0 {
                 monitor.pertag.prevtag = monitor.pertag.curtag;
@@ -441,19 +435,15 @@ pub(crate) fn toggleview(state: &mut State, arg: *const Arg) {
             }
 
             // apply settings for this view
-            monitor.nmaster =
-                monitor.pertag.nmasters[monitor.pertag.curtag as usize];
-            monitor.mfact =
-                monitor.pertag.mfacts[monitor.pertag.curtag as usize];
-            monitor.sellt =
-                monitor.pertag.sellts[monitor.pertag.curtag as usize];
-            monitor.lt[monitor.sellt as usize] = monitor.pertag.ltidxs
-                [monitor.pertag.curtag as usize][monitor.sellt as usize];
-            monitor.lt[(monitor.sellt ^ 1) as usize] = monitor.pertag.ltidxs
-                [monitor.pertag.curtag as usize][(monitor.sellt ^ 1) as usize];
+            monitor.nmaster = monitor.pertag.nmasters[monitor.pertag.curtag];
+            monitor.mfact = monitor.pertag.mfacts[monitor.pertag.curtag];
+            monitor.sellt = monitor.pertag.sellts[monitor.pertag.curtag];
+            monitor.lt[monitor.sellt] =
+                monitor.pertag.ltidxs[monitor.pertag.curtag][monitor.sellt];
+            monitor.lt[monitor.sellt ^ 1] =
+                monitor.pertag.ltidxs[monitor.pertag.curtag][monitor.sellt ^ 1];
 
-            if monitor.showbar
-                != monitor.pertag.showbars[monitor.pertag.curtag as usize]
+            if monitor.showbar != monitor.pertag.showbars[monitor.pertag.curtag]
             {
                 togglebar(state, null_mut());
             }
@@ -553,7 +543,7 @@ pub(crate) fn movemouse(state: &mut State, _arg: *const Arg) {
                             (*state.selmon).wy + (*state.selmon).wh - height(c);
                     }
                     if !c.isfloating
-                        && (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+                        && (*(*state.selmon).lt[(*state.selmon).sellt])
                             .arrange
                             .is_some()
                         && ((nx - c.x).abs() > state.config.snap as c_int
@@ -561,7 +551,7 @@ pub(crate) fn movemouse(state: &mut State, _arg: *const Arg) {
                     {
                         togglefloating(state, null_mut());
                     }
-                    if (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+                    if (*(*state.selmon).lt[(*state.selmon).sellt])
                         .arrange
                         .is_none()
                         || c.isfloating
@@ -653,7 +643,7 @@ pub(crate) fn resizemouse(state: &mut State, _arg: *const Arg) {
                         && (*c.mon).wy + nh
                             <= (*state.selmon).wy + (*state.selmon).wh
                         && !c.isfloating
-                        && (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+                        && (*(*state.selmon).lt[(*state.selmon).sellt])
                             .arrange
                             .is_some()
                         && ((nw - c.w).abs() > state.config.snap as c_int
@@ -661,7 +651,7 @@ pub(crate) fn resizemouse(state: &mut State, _arg: *const Arg) {
                     {
                         togglefloating(state, null_mut());
                     }
-                    if (*(*state.selmon).lt[(*state.selmon).sellt as usize])
+                    if (*(*state.selmon).lt[(*state.selmon).sellt])
                         .arrange
                         .is_none()
                         || c.isfloating
@@ -707,8 +697,7 @@ pub(crate) fn spawn(state: &mut State, arg: *const Arg) {
             argv.push((*state.selmon).num.to_string());
         }
 
-        (*state.selmon).tagset[(*state.selmon).seltags as usize] &=
-            !state.scratchtag();
+        (*state.selmon).tagset[(*state.selmon).seltags] &= !state.scratchtag();
 
         let mut cmd = Command::new(argv[0].clone());
         let cmd = if argv.len() > 1 { cmd.args(&argv[1..]) } else { &mut cmd };
@@ -766,12 +755,10 @@ pub(crate) fn togglescratch(state: &mut State, arg: *const Arg) {
             }
         });
         if found {
-            let newtagset = (*state.selmon).tagset
-                [(*state.selmon).seltags as usize]
+            let newtagset = (*state.selmon).tagset[(*state.selmon).seltags]
                 ^ state.scratchtag();
             if newtagset != 0 {
-                (*state.selmon).tagset[(*state.selmon).seltags as usize] =
-                    newtagset;
+                (*state.selmon).tagset[(*state.selmon).seltags] = newtagset;
                 focus(state, null_mut());
                 arrange(state, state.selmon);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,15 +187,15 @@ pub struct Layout {
 #[derive(Clone, Debug)]
 pub struct Pertag {
     /// Current tag
-    pub curtag: c_uint,
+    pub curtag: usize,
     /// Previous tag
-    pub prevtag: c_uint,
+    pub prevtag: usize,
     /// Number of windows in master area
     pub nmasters: Vec<c_int>,
     /// Proportion of monitor for master area
     pub mfacts: Vec<f32>,
     /// Selected layouts
-    pub sellts: Vec<c_uint>,
+    pub sellts: Vec<usize>,
     /// Matrix of tag and layout indices
     pub ltidxs: Vec<[*const Layout; 2]>,
     /// Whether to display the bar
@@ -218,8 +218,8 @@ pub struct Monitor {
     pub wy: c_int,
     pub ww: c_int,
     pub wh: c_int,
-    pub seltags: c_uint,
-    pub sellt: c_uint,
+    pub seltags: usize,
+    pub sellt: usize,
     pub tagset: [c_uint; 2usize],
     pub showbar: bool,
     pub topbar: bool,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,7 +55,7 @@ fn main() {
         .into_button();
         handlers::buttonpress(&mut state, &mut button);
         unsafe {
-            assert!((*(*state.selmon).lt[(*state.selmon).sellt as usize])
+            assert!((*(*state.selmon).lt[(*state.selmon).sellt])
                 .arrange
                 .is_none());
         }


### PR DESCRIPTION
I noticed these while updating some clippy lints. Many fields were always being cast to usize, so we might as well just use usize directly.